### PR TITLE
Move dynamic pdb-redo data loading to StructuresTable

### DIFF
--- a/app/assets/javascripts/covid19/package.json
+++ b/app/assets/javascripts/covid19/package.json
@@ -24,7 +24,6 @@
         "react-dom": "17.0.1",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
-        "react-use-localstorage": "^3.5.3",
         "styled-components": "^5.3.0",
         "styled-jsx": "3.3.2"
     },

--- a/app/assets/javascripts/covid19/src/compositionRoot.ts
+++ b/app/assets/javascripts/covid19/src/compositionRoot.ts
@@ -2,14 +2,23 @@ import { Covid19InfoFromJsonRepository } from "./data/Covid19InfoFromJsonReposit
 import { BrowserDataGridRepository } from "./data/BrowserDataGridRepository";
 import { ExportStructuresUseCase } from "./domain/usecases/ExportStructuresUseCase";
 import { GetCovid19InfoUseCase } from "./domain/usecases/GetCovid19InfoUseCase";
+import { SearchCovid19InfoUseCase } from "./domain/usecases/SearchCovid19InfoUseCase";
+import { AddDynamicInfoToCovid19InfoUseCase } from "./domain/usecases/AddDynamicInfoToCovid19InfoUseCase";
+import { LocalStorageCacheRepository } from "./data/LocalStorageCacheRepository";
 
 export function getCompositionRoot() {
     const covid19InfoRepository = new Covid19InfoFromJsonRepository();
     const dataGridRepository = new BrowserDataGridRepository();
+    const cacheRepository = new LocalStorageCacheRepository();
 
     return {
         getCovid19Info: new GetCovid19InfoUseCase(covid19InfoRepository),
+        searchCovid19Info: new SearchCovid19InfoUseCase(covid19InfoRepository),
         exportStructures: new ExportStructuresUseCase(dataGridRepository),
+        addDynamicInfo: new AddDynamicInfoToCovid19InfoUseCase(
+            covid19InfoRepository,
+            cacheRepository
+        ),
     };
 }
 

--- a/app/assets/javascripts/covid19/src/data/LocalStorageCacheRepository.ts
+++ b/app/assets/javascripts/covid19/src/data/LocalStorageCacheRepository.ts
@@ -1,0 +1,13 @@
+import { CacheRepository } from "../domain/repositories/CacheRepository";
+
+export class LocalStorageCacheRepository implements CacheRepository {
+    get<T>(key: string): T | undefined {
+        const value = localStorage.getItem(key);
+        return value === null ? undefined : (JSON.parse(value) as T);
+    }
+
+    set<T>(key: string, value: T): void {
+        const json = JSON.stringify(value);
+        localStorage.setItem(key, json);
+    }
+}

--- a/app/assets/javascripts/covid19/src/domain/entities/Covid19Info.ts
+++ b/app/assets/javascripts/covid19/src/domain/entities/Covid19Info.ts
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 export interface Covid19Info {
     structures: Structure[];
 }
@@ -131,4 +133,25 @@ export function buildPdbRedoValidation(pdbId: Id): PdbRedoValidation {
         queryLink: `/pdb_redo/${pdbId}`,
         badgeColor: "w3-turq",
     };
+}
+
+export function addPdbValidationToStructure(
+    structure: Structure,
+    validation: PdbValidation
+): Structure {
+    const existingValidations = structure.validations.pdb;
+    const structureContainsValidation = _(existingValidations).some(existingValidation =>
+        _.isEqual(existingValidation, validation)
+    );
+
+    if (!structureContainsValidation) {
+        const pdbValidations = _.concat(existingValidations, [validation]);
+
+        return {
+            ...structure,
+            validations: { ...structure.validations, pdb: pdbValidations },
+        };
+    } else {
+        return structure;
+    }
 }

--- a/app/assets/javascripts/covid19/src/domain/repositories/CacheRepository.ts
+++ b/app/assets/javascripts/covid19/src/domain/repositories/CacheRepository.ts
@@ -1,0 +1,20 @@
+export interface CacheRepository {
+    get<T>(key: string): T | undefined;
+    set<T>(key: string, value: T): void;
+}
+
+export async function fromCache<T>(
+    repository: CacheRepository,
+    options: { key: string; get: () => Promise<T> }
+): Promise<T> {
+    const { key, get } = options;
+    const valueFromCache = repository.get<T>(key);
+
+    if (valueFromCache !== undefined) {
+        return valueFromCache;
+    } else {
+        const value = await get();
+        repository.set(key, value);
+        return value;
+    }
+}

--- a/app/assets/javascripts/covid19/src/domain/repositories/Covid19InfoRepository.ts
+++ b/app/assets/javascripts/covid19/src/domain/repositories/Covid19InfoRepository.ts
@@ -3,9 +3,11 @@ import { Covid19Info, EntityBodiesFilter } from "../entities/Covid19Info";
 export interface Covid19InfoRepository {
     get(): Covid19Info;
     search(options: SearchOptions): Covid19Info;
+    hasPdbRedoValidation(pdbId: string): Promise<boolean>;
 }
 
 export interface SearchOptions {
+    data: Covid19Info;
     search?: string;
     filter?: EntityBodiesFilter;
 }

--- a/app/assets/javascripts/covid19/src/domain/usecases/AddDynamicInfoToCovid19InfoUseCase.ts
+++ b/app/assets/javascripts/covid19/src/domain/usecases/AddDynamicInfoToCovid19InfoUseCase.ts
@@ -1,0 +1,51 @@
+import _ from "lodash";
+import {
+    addPdbValidationToStructure,
+    buildPdbRedoValidation,
+    Covid19Info,
+} from "../entities/Covid19Info";
+import { CacheRepository, fromCache } from "../repositories/CacheRepository";
+import { Covid19InfoRepository } from "../repositories/Covid19InfoRepository";
+
+export class AddDynamicInfoToCovid19InfoUseCase {
+    constructor(
+        private covid19InfoRepository: Covid19InfoRepository,
+        private cacheRepository: CacheRepository
+    ) {}
+
+    execute(data: Covid19Info, options: { ids: string[] }) {
+        return this.addPdbRedoValidation(data, options);
+    }
+
+    async addPdbRedoValidation(
+        data: Covid19Info,
+        options: { ids: string[] }
+    ): Promise<Covid19Info> {
+        if (_.isEmpty(options.ids)) return data;
+
+        const structuresById = _.keyBy(data.structures, structure => structure.id);
+        const structuresToUpdate = _(structuresById).at(options.ids).compact().value();
+
+        const structuresUpdated$ = structuresToUpdate.map(async structure => {
+            const { pdb } = structure;
+            if (!pdb) return structure;
+
+            const validation = buildPdbRedoValidation(pdb.id);
+
+            const hasPdbRedo = await fromCache(this.cacheRepository, {
+                key: `pdb-${pdb.id}`,
+                get: () => this.covid19InfoRepository.hasPdbRedoValidation(pdb.id),
+            });
+
+            return hasPdbRedo ? addPdbValidationToStructure(structure, validation) : structure;
+        });
+
+        const structuresUpdated = await Promise.all(structuresUpdated$);
+        if (_.isEqual(structuresToUpdate, structuresUpdated)) return data;
+
+        const structuresUpdatedById = _.keyBy(structuresUpdated, structure => structure.id);
+        const structures2 = data.structures.map(st => structuresUpdatedById[st.id] || st);
+
+        return { structures: structures2 };
+    }
+}

--- a/app/assets/javascripts/covid19/src/domain/usecases/GetCovid19InfoUseCase.ts
+++ b/app/assets/javascripts/covid19/src/domain/usecases/GetCovid19InfoUseCase.ts
@@ -1,9 +1,9 @@
-import { Covid19InfoRepository, SearchOptions } from "../repositories/Covid19InfoRepository";
+import { Covid19InfoRepository } from "../repositories/Covid19InfoRepository";
 
 export class GetCovid19InfoUseCase {
     constructor(private covid19InfoRepository: Covid19InfoRepository) {}
 
-    execute(options: SearchOptions) {
-        return this.covid19InfoRepository.search(options);
+    execute() {
+        return this.covid19InfoRepository.get();
     }
 }

--- a/app/assets/javascripts/covid19/src/domain/usecases/SearchCovid19InfoUseCase.ts
+++ b/app/assets/javascripts/covid19/src/domain/usecases/SearchCovid19InfoUseCase.ts
@@ -1,0 +1,9 @@
+import { Covid19InfoRepository, SearchOptions } from "../repositories/Covid19InfoRepository";
+
+export class SearchCovid19InfoUseCase {
+    constructor(private covid19InfoRepository: Covid19InfoRepository) {}
+
+    execute(options: SearchOptions) {
+        return this.covid19InfoRepository.search(options);
+    }
+}

--- a/app/assets/javascripts/covid19/src/webapp/components/app/Root.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/app/Root.tsx
@@ -1,16 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+
 import i18n from "../../../utils/i18n";
-import { useAppContext } from "../../contexts/app-context";
 import { StructuresTable } from "../structures-table/StructuresTable";
 
-interface RootProps {}
-
-export const Root: React.FC<RootProps> = React.memo(() => {
-    const { compositionRoot } = useAppContext();
-    const data = compositionRoot.getCovid19Info.execute({});
-    window.app = { data };
-
+export const Root: React.FC = React.memo(() => {
     return (
         <Body>
             <HeaderBanner>

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/StructuresTable.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/StructuresTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "lodash";
 import { makeStyles } from "@material-ui/core";
 import { DataGrid, DataGridProps } from "@material-ui/data-grid";
-import { EntityBodiesFilter } from "../../../domain/entities/Covid19Info";
+import { EntityBodiesFilter, Id } from "../../../domain/entities/Covid19Info";
 import { getColumns } from "./Columns";
 import { Toolbar, ToolbarProps } from "./Toolbar";
 import { useVirtualScrollbarForDataGrid } from "../VirtualScrollbar";
@@ -20,19 +20,36 @@ export const StructuresTable: React.FC<StructuresTableProps> = React.memo(() => 
     const [search, setSearch] = React.useState("");
     const [filterState, setFilterState] = React.useState(initialFilterState);
 
-    const data = React.useMemo(() => {
-        return compositionRoot.getCovid19Info.execute({ search, filter: filterState });
-    }, [compositionRoot, search, filterState]);
-
-    const columns = React.useMemo(() => getColumns(data), [data]);
-    const components = React.useMemo(() => ({ Toolbar: Toolbar }), []);
-    const { structures } = data;
-
     const {
         gridApi,
         virtualScrollbarProps,
         updateScrollBarFromStateChange,
     } = useVirtualScrollbarForDataGrid();
+
+    const [renderedRowIds, setRenderedRowsFromState] = useRenderedRows();
+
+    const onStateChange = React.useCallback<NonNullable<DataGridProps["onStateChange"]>>(
+        params => {
+            setRenderedRowsFromState(params);
+            updateScrollBarFromStateChange(params);
+        },
+        [setRenderedRowsFromState, updateScrollBarFromStateChange]
+    );
+
+    const [data, setData] = React.useState(() => compositionRoot.getCovid19Info.execute());
+    window.app = { data };
+
+    React.useEffect(() => {
+        compositionRoot.addDynamicInfo.execute(data, { ids: renderedRowIds }).then(setData);
+    }, [compositionRoot, data, renderedRowIds]);
+
+    const filteredData = React.useMemo(() => {
+        return compositionRoot.searchCovid19Info.execute({ data, search, filter: filterState });
+    }, [compositionRoot, data, search, filterState]);
+
+    const { structures } = filteredData;
+    const columns = React.useMemo(() => getColumns(data), [data]);
+    const components = React.useMemo(() => ({ Toolbar: Toolbar }), []);
 
     const dataGrid = React.useMemo<DataGridE>(() => {
         return { columns: columns.base, structures };
@@ -85,7 +102,7 @@ export const StructuresTable: React.FC<StructuresTableProps> = React.memo(() => 
         <div className={classes.wrapper}>
             <DataGrid
                 page={page}
-                onStateChange={updateScrollBarFromStateChange}
+                onStateChange={onStateChange}
                 onSortModelChange={setFirstPage}
                 className={classes.root}
                 rowHeight={220}
@@ -128,3 +145,27 @@ const initialFilterState: EntityBodiesFilter = {
     nanobody: false,
     sybody: false,
 };
+
+function useRenderedRows() {
+    const [renderedRowIds, setRenderedRowIds] = React.useState<Id[]>([]);
+
+    const setRenderedRowsFromState = React.useCallback<NonNullable<DataGridProps["onStateChange"]>>(
+        gridParams => {
+            const { api } = gridParams;
+            const { page, pageSize } = gridParams.state.pagination;
+            const sortedIds = api.getSortedRowIds() as Id[];
+            const visibleIds = Array.from(api.getVisibleRowModels().keys()) as string[];
+
+            const ids = _(sortedIds)
+                .intersection(visibleIds)
+                .drop(page * pageSize)
+                .take(pageSize)
+                .value();
+
+            setRenderedRowIds(prevIds => (_.isEqual(prevIds, ids) ? prevIds : ids));
+        },
+        []
+    );
+
+    return [renderedRowIds, setRenderedRowsFromState] as const;
+}

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/PdbCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/PdbCell.tsx
@@ -4,21 +4,16 @@ import i18n from "../../../../utils/i18n";
 import { CellProps } from "../Columns";
 import { Thumbnail } from "../Thumbnail";
 import { BadgeLink } from "../BadgeLink";
-import {
-    buildPdbRedoValidation,
-    Pdb,
-    PdbValidation,
-} from "../../../../domain/entities/Covid19Info";
-import useLocalStorage from "react-use-localstorage";
+import { Pdb, Structure } from "../../../../domain/entities/Covid19Info";
 
 export const PdbCell: React.FC<CellProps> = React.memo(props => {
     const { pdb } = props.row;
-    return pdb ? <PdbCell2 pdb={pdb} /> : null;
+    return pdb ? <PdbCell2 structure={props.row} pdb={pdb} /> : null;
 });
 
-const PdbCell2: React.FC<{ pdb: Pdb }> = React.memo(props => {
-    const { pdb } = props;
-    const pdbValidations = usePdbRedoValidations(pdb);
+const PdbCell2: React.FC<{ structure: Structure; pdb: Pdb }> = React.memo(props => {
+    const { pdb, structure } = props;
+    const pdbValidations = structure.validations.pdb;
 
     const tooltip = (
         <React.Fragment>
@@ -89,39 +84,3 @@ const PdbCell2: React.FC<{ pdb: Pdb }> = React.memo(props => {
         </React.Fragment>
     );
 });
-
-async function checkUrl(url: string): Promise<boolean> {
-    try {
-        const res = await fetch(url, { method: "HEAD" });
-        return res.status === 200;
-    } catch (err) {
-        return false;
-    }
-}
-
-const values = { true: "1", false: "0", undefined: "undefined" } as const;
-
-function usePdbRedoValidations(pdb: Pdb): PdbValidation[] {
-    const [hasPdbValidation, setHasPdbValidation] = useLocalStorage(
-        `pdb-${pdb.id}`,
-        values.undefined
-    );
-
-    const checkPdb = React.useCallback(async () => {
-        const pdbRedoUrl = buildPdbRedoValidation(pdb.id).externalLink;
-        const pdbRedoAvailable = await checkUrl(pdbRedoUrl);
-        setHasPdbValidation(pdbRedoAvailable ? values.true : values.false);
-    }, [pdb.id, setHasPdbValidation]);
-
-    React.useEffect(() => {
-        if (hasPdbValidation === values.undefined) checkPdb();
-    }, [hasPdbValidation, checkPdb]);
-
-    const hasPdbRedoValidations = hasPdbValidation === values.true;
-
-    const pdbValidations = React.useMemo(() => {
-        return hasPdbRedoValidations ? [buildPdbRedoValidation(pdb.id)] : [];
-    }, [hasPdbRedoValidations, pdb.id]);
-
-    return pdbValidations;
-}

--- a/app/assets/javascripts/covid19/yarn.lock
+++ b/app/assets/javascripts/covid19/yarn.lock
@@ -12481,11 +12481,6 @@ react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-use-localstorage@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.npmjs.org/react-use-localstorage/-/react-use-localstorage-3.5.3.tgz#c4bcc097859a2d2879e969f0a57b16345905df82"
-  integrity sha512-1oNvJmo72G4v5P9ytJZZTb6ywD3UzWBiainTtfbNlb+U08hc+SOD5HqgiLTKUF0MxGcIR9JSnZGmBttNLXaQYA==
-
 react@17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"


### PR DESCRIPTION
[demo PR, not to be merged] @jvfdunkley 

- I've moved all logic from `PdbCell` to `StructuresTable`, as now we want to filter by PDB validations.
- I've removed `useLocalStorage` altogether and created a `CacheRepository` instead (to be called from use cases or other repositories). This way, we decouple the caching from React infrastructure, which is always nice.
-  `useRenderedRows` restores some code we had and need again, as we load the validations on the parent `StructureTable` only for the rendered/visible rows, not within the PDB cell (where we were certain it was going to be rendered).
- Now the workflow is: 1) Load the covid19 data (without PDB validations), we can already render 2) Load PDB validations on the background and re-render rows when finished, and 3) Filter the data (which contain the validations, so you can now add the new filter there).

Feel free to refactor it as you see fit. 