### PR TITLE
Style filters

### DIFF
--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import _ from "lodash";
 import { Covid19Filter, FilterKey, getTranslations } from "../../../domain/entities/Covid19Info";
-import { MenuItem, MenuList, Divider, Checkbox } from "@material-ui/core";
+import { MenuItem, MenuList, Divider, Checkbox, Button } from "@material-ui/core";
 import { GridMenu } from "@material-ui/data-grid";
 import i18n from "../../../utils/i18n";
-import { StyledSearchExampleButton } from "./SearchExampleButton";
 import FilterListIcon from "@material-ui/icons/FilterList";
 import styled from "styled-components";
 
@@ -42,18 +41,17 @@ export const CustomCheckboxFilter: React.FC<CustomCheckboxFilterProps> = React.m
 
     return (
         <React.Fragment>
-            <StyledSearchExampleButton
+            <FilterButton
                 color="primary"
-                size="small"
                 onClick={openMenu}
                 aria-expanded={Boolean(anchorEl)}
                 aria-label="toolbarExportLabel"
                 aria-haspopup="menu"
                 endIcon={startIcon}
-                style={{ margin: "auto 5px" }}
+                style={{ margin: "auto 5px auto 10px" }}
             >
                 {i18n.t("Filter")}
-            </StyledSearchExampleButton>
+            </FilterButton>
 
             <GridMenu
                 open={isOpen}
@@ -106,4 +104,27 @@ const StyledCheckbox = styled(Checkbox)`
         color: #484848;
     }
     padding: 0 8px 0 0 !important;
+`;
+
+const FilterButton = styled(Button)`
+    &.MuiButton-root {
+        padding: 6px 16px;
+        margin: 12px 6px;
+        color: #fff;
+        height: 45px;
+        font-weight: 500;
+        text-align: center;
+        border-radius: 0.75rem;
+        background-color: #607d8b;
+        border-color: #607d8b;
+        font-size: 0.875rem;
+        line-height: 45px;
+        &:focus {
+            outline: none;
+        }
+        &:hover {
+            border-color: #82a4b5;
+            background-color: #82a4b5;
+        }
+    }
 `;

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
@@ -103,6 +103,7 @@ export const CustomCheckboxFilter: React.FC<CustomCheckboxFilterProps> = React.m
 
 const StyledCheckbox = styled(Checkbox)`
     &.MuiCheckbox-colorSecondary.Mui-checked {
-        color: grey;
+        color: #484848;
     }
+    padding: 0 8px 0 0 !important;
 `;

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/CustomCheckboxFilter.tsx
@@ -48,7 +48,6 @@ export const CustomCheckboxFilter: React.FC<CustomCheckboxFilterProps> = React.m
                 aria-label="toolbarExportLabel"
                 aria-haspopup="menu"
                 endIcon={startIcon}
-                style={{ margin: "auto 5px auto 10px" }}
             >
                 {i18n.t("Filter")}
             </FilterButton>
@@ -109,7 +108,7 @@ const StyledCheckbox = styled(Checkbox)`
 const FilterButton = styled(Button)`
     &.MuiButton-root {
         padding: 6px 16px;
-        margin: 12px 6px;
+        margin: auto 5px auto 10px;
         color: #fff;
         height: 45px;
         font-weight: 500;

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchBar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchBar.tsx
@@ -5,7 +5,7 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import parse from "autosuggest-highlight/parse";
 import match from "autosuggest-highlight/match";
 import styled from "styled-components";
-import SearchIcon from "@material-ui/icons/Search";
+import { Close as CloseIcon, Search as SearchIcon } from "@material-ui/icons";
 import i18n from "../../../utils/i18n";
 import { useDebouncedSetter } from "../../hooks/useDebounce";
 import {
@@ -59,13 +59,11 @@ export const SearchBar: React.FC<SearchBarProps> = React.memo(props => {
             <div style={styles.searchBar}>
                 <div style={styles.chips}>
                     {selectedFilterNames.map(filterKey => (
-                        <li key={filterKey}>
-                            <Chip
-                                label={t.filterKeys[filterKey]}
-                                onDelete={() => removeChip(filterKey)}
-                                style={styles.chip}
-                            />
-                        </li>
+                        <StyledChip
+                            deleteIcon={<CloseIcon />}
+                            label={t.filterKeys[filterKey]}
+                            onDelete={() => removeChip(filterKey)}
+                        />
                     ))}
                 </div>
                 <StyledAutocomplete<string>
@@ -144,6 +142,23 @@ const StyledTextField = styled(TextField)`
     }
 `;
 
+const StyledChip = styled(Chip)`
+    &.MuiChip-root {
+        height: 1.5rem !important;
+        background-color: #575757 !important;
+        color: #fff;
+        margin-left: 6px;
+        border-radius: 8px;
+    }
+    .MuiChip-deleteIcon {
+        width: 1rem;
+        color: rgba(255, 255, 255, 0.7);
+    }
+    .MuiChip-deleteIcon:hover {
+        color: rgba(255, 255, 255, 1);
+    }
+`;
+
 const styles = {
     searchBar: {
         display: "flex" as const,
@@ -151,11 +166,9 @@ const styles = {
         borderRadius: 12,
         width: 500,
     },
-    chip: { margin: 2 },
     chips: {
         display: "flex" as const,
-        justifyContent: "center",
-        flexWrap: "wrap" as const,
+        alignItems: "center",
         listStyle: "none",
         margin: 0,
     },

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchBar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchBar.tsx
@@ -60,6 +60,7 @@ export const SearchBar: React.FC<SearchBarProps> = React.memo(props => {
                 <div style={styles.chips}>
                     {selectedFilterNames.map(filterKey => (
                         <StyledChip
+                            key={filterKey}
                             deleteIcon={<CloseIcon />}
                             label={t.filterKeys[filterKey]}
                             onDelete={() => removeChip(filterKey)}
@@ -163,7 +164,7 @@ const styles = {
     searchBar: {
         display: "flex" as const,
         border: "4px solid #607d8b",
-        borderRadius: 12,
+        borderRadius: "0.75rem",
         width: 500,
     },
     chips: {

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchExampleButton.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchExampleButton.tsx
@@ -9,9 +9,12 @@ interface SearchExampleButtonProps {
 
 export const SearchExampleButton: React.FC<SearchExampleButtonProps> = React.memo(props => {
     const { exampleValue, setValue } = props;
-
+    const setValueExample = React.useCallback(() => setValue(exampleValue), [
+        setValue,
+        exampleValue,
+    ]);
     return (
-        <StyledSearchExampleButton onClick={() => setValue(exampleValue)}>
+        <StyledSearchExampleButton onClick={setValueExample}>
             {exampleValue}
         </StyledSearchExampleButton>
     );

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchExampleButton.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/SearchExampleButton.tsx
@@ -11,11 +11,7 @@ export const SearchExampleButton: React.FC<SearchExampleButtonProps> = React.mem
     const { exampleValue, setValue } = props;
 
     return (
-        <StyledSearchExampleButton
-            variant="contained"
-            size="small"
-            onClick={() => setValue(exampleValue)}
-        >
+        <StyledSearchExampleButton onClick={() => setValue(exampleValue)}>
             {exampleValue}
         </StyledSearchExampleButton>
     );
@@ -23,15 +19,15 @@ export const SearchExampleButton: React.FC<SearchExampleButtonProps> = React.mem
 
 export const StyledSearchExampleButton = styled(Button)`
     &.MuiButton-root {
-        padding: 6px 12px;
+        padding: 6px 16px;
         margin: 12px 6px;
         color: #fff;
-        font-weight: 700;
+        font-weight: 500;
         text-align: center;
-        border-radius: 0.25rem;
+        border-radius: 0.75rem;
         background-color: #607d8b;
         border-color: #607d8b;
-        font-size: 11px;
+        font-size: 0.75rem;
         &:focus {
             outline: none;
         }

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
@@ -59,6 +59,10 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                             filterState={filterState}
                             setFilterState={setFilterState}
                         />
+                        <CustomCheckboxFilter
+                            filterState={filterState}
+                            setFilterState={setFilterState}
+                        />
                         <Tooltip
                             title={
                                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas cursus pellentesque risus, nec accumsan turpis sagittis non. Duis hendrerit nec odio eu hendrerit. Morbi pellentesque ligula a dui malesuada, nec eleifend massa lacinia. Aliquam non efficitur tellus. Curabitur varius neque at mauris vulputate, eu mattis massa porta. Donec aliquet luctus augue, nec pulvinar enim pharetra a. Ut varius nibh mauris, quis finibus justo lobortis sed. In ultricies dolor et orci hendrerit, et commodo diam accumsan."
@@ -66,10 +70,6 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                         >
                             <span style={styles.tooltip}>?</span>
                         </Tooltip>
-                        <CustomCheckboxFilter
-                            filterState={filterState}
-                            setFilterState={setFilterState}
-                        />
                     </div>
                     <div style={styles.exampleRow}>
                         <p style={styles.examplesText}>{i18n.t("Examples")}:</p>

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
@@ -108,7 +108,7 @@ export const styles = {
     container: {
         display: "flex",
         flexDirection: "column" as const,
-        padding: 10,
+        padding: "14px 14px 0px 14px",
         alignItems: "flex-start",
     },
     toolbarRow: {

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
@@ -53,8 +53,8 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
     return (
         <React.Fragment>
             <GridToolbarContainer style={styles.container}>
-                <div style={{ display: "flex", flexDirection: "column" }}>
-                    <div style={{ display: "flex" }}>
+                <div style={styles.toolbarRow}>
+                    <div style={{ display: "flex", flexGrow: 1 }}>
                         <SearchBar
                             value={search}
                             setValue={setSearch}
@@ -75,28 +75,29 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                             </span>
                         </Tooltip>
                     </div>
+                    <GridToolbarActions>
+                        <CustomGridToolbarExport dataGrid={dataGrid} gridApi={gridApi} />
+                        <GridToolbarColumnsButton />
+                    </GridToolbarActions>
+                </div>
+
+                <div style={styles.toolbarRow}>
                     <div style={styles.exampleRow}>
                         <p style={styles.examplesText}>{i18n.t("Examples")}:</p>
                         <SearchExampleButton setValue={setSearch} exampleValue="6YOR" />
                         <SearchExampleButton setValue={setSearch} exampleValue="Homo sapiens" />
                         <SearchExampleButton setValue={setSearch} exampleValue="SARS-CoV-2" />
                     </div>
+                    <CustomGridTopPagination
+                        dataGrid={dataGrid}
+                        page={page}
+                        pageSize={pageSize}
+                        pageSizes={pageSizes}
+                        setPage={setPage}
+                        setPageSize={setPageSize}
+                    />
                 </div>
-
-                <GridToolbarActions>
-                    <CustomGridToolbarExport dataGrid={dataGrid} gridApi={gridApi} />
-                    <GridToolbarColumnsButton />
-                </GridToolbarActions>
             </GridToolbarContainer>
-
-            <CustomGridTopPagination
-                dataGrid={dataGrid}
-                page={page}
-                pageSize={pageSize}
-                pageSizes={pageSizes}
-                setPage={setPage}
-                setPageSize={setPageSize}
-            />
 
             <VirtualScroll {...virtualScrollbarProps} />
         </React.Fragment>
@@ -104,12 +105,17 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
 };
 
 export const styles = {
-    container: { padding: 10, alignItems: "flex-start" },
-    containerPagination: {
+    container: {
         display: "flex",
-        justifyContent: "right",
         flexDirection: "column" as const,
-        marginLeft: "auto",
+        padding: 10,
+        alignItems: "flex-start",
+    },
+    toolbarRow: {
+        display: "flex",
+        flexDirection: "row" as const,
+        width: "100%",
+        alignItems: "center",
     },
     tooltip: {
         display: "flex",
@@ -126,7 +132,7 @@ export const styles = {
         outline: "none",
         cursor: "pointer",
     },
-    exampleRow: { display: "flex" as const, alignItems: "center" },
+    exampleRow: { display: "flex" as const, alignItems: "center", marginRight: "auto" },
     examplesText: { margin: 0 },
 };
 

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
@@ -11,7 +11,9 @@ import "./Toolbar.css";
 import { CustomCheckboxFilter } from "./CustomCheckboxFilter";
 import { Covid19Filter } from "../../../domain/entities/Covid19Info";
 import { SearchExampleButton } from "./SearchExampleButton";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import i18n from "../../../utils/i18n";
+import styled from "styled-components";
 
 export interface ToolbarProps {
     search: string;
@@ -68,7 +70,9 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas cursus pellentesque risus, nec accumsan turpis sagittis non. Duis hendrerit nec odio eu hendrerit. Morbi pellentesque ligula a dui malesuada, nec eleifend massa lacinia. Aliquam non efficitur tellus. Curabitur varius neque at mauris vulputate, eu mattis massa porta. Donec aliquet luctus augue, nec pulvinar enim pharetra a. Ut varius nibh mauris, quis finibus justo lobortis sed. In ultricies dolor et orci hendrerit, et commodo diam accumsan."
                             }
                         >
-                            <span style={styles.tooltip}>?</span>
+                            <span style={styles.tooltip}>
+                                <HelpOutlineIcon />
+                            </span>
                         </Tooltip>
                     </div>
                     <div style={styles.exampleRow}>
@@ -79,11 +83,12 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                     </div>
                 </div>
 
-                <div style={styles.columns}>
+                <GridToolbarActions>
                     <CustomGridToolbarExport dataGrid={dataGrid} gridApi={gridApi} />
                     <GridToolbarColumnsButton />
-                </div>
+                </GridToolbarActions>
             </GridToolbarContainer>
+
             <CustomGridTopPagination
                 dataGrid={dataGrid}
                 page={page}
@@ -92,21 +97,31 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
                 setPage={setPage}
                 setPageSize={setPageSize}
             />
+
             <VirtualScroll {...virtualScrollbarProps} />
         </React.Fragment>
     );
 };
 
 export const styles = {
-    container: { padding: 10 },
-    columns: { marginLeft: "auto" },
+    container: { padding: 10, alignItems: "flex-start" },
+    containerPagination: {
+        display: "flex",
+        justifyContent: "right",
+        flexDirection: "column" as const,
+        marginLeft: "auto",
+    },
     tooltip: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         fontWeight: 700,
-        padding: "7px 10px",
+        height: "45px",
+        width: "45px",
         margin: "auto 5px",
         color: "#ffffff",
         backgroundColor: "rgb(96, 125, 139)",
-        borderRadius: 8,
+        borderRadius: "0.75rem",
         border: "solid 0px rgb(96, 125, 139)",
         outline: "none",
         cursor: "pointer",
@@ -118,3 +133,18 @@ export const styles = {
 function isNonEmptyObject<T>(obj: T | {}): obj is T {
     return Object.keys(obj).length > 0;
 }
+
+const GridToolbarActions = styled.div`
+    display: flex;
+    align-items: center;
+    height: 45px;
+    margin-left: auto;
+    .MuiButton-textSizeSmall {
+        padding: 6px 8px;
+        font-size: 1rem;
+        color: #607d8b;
+        .MuiButton-iconSizeSmall > *:first-child {
+            font-size: 1.5rem;
+        }
+    }
+`;

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Toolbar.tsx
@@ -54,7 +54,7 @@ export const Toolbar: React.FC<ToolbarProps | {}> = props => {
         <React.Fragment>
             <GridToolbarContainer style={styles.container}>
                 <div style={styles.toolbarRow}>
-                    <div style={{ display: "flex", flexGrow: 1 }}>
+                    <div style={styles.searchBar}>
                         <SearchBar
                             value={search}
                             setValue={setSearch}
@@ -134,6 +134,7 @@ export const styles = {
     },
     exampleRow: { display: "flex" as const, alignItems: "center", marginRight: "auto" },
     examplesText: { margin: 0 },
+    searchBar: { display: "flex", flexGrow: 1 },
 };
 
 function isNonEmptyObject<T>(obj: T | {}): obj is T {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/1yyv871

### :memo: Implementation

Decreased filter list padding, change style buttons, and change distribution of Toolbar (pagination moved inside toolbar and creted two rows instead of cols; so pagination can fit next to the examples in small screens). Help button moved to the left. Chips now are in a single row.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/43061485/155743724-7c3fe704-a0e5-4c6f-82a2-7384dfc91134.png)
![image](https://user-images.githubusercontent.com/43061485/155743829-5282ad36-1f65-47b5-80ee-7f240405679a.png)
![image](https://user-images.githubusercontent.com/43061485/156145659-7d82cd5b-e717-4f63-a06e-19bf2edbfd63.png)
