### PR TITLE
[Development] Change links that go to the viewer

### DIFF
--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/Thumbnail.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/Thumbnail.tsx
@@ -4,6 +4,7 @@ import { styles } from "./Columns";
 import { BadgeLink } from "./BadgeLink";
 import { Tooltip } from "./Link";
 import { HtmlTooltip } from "./HtmlTooltip";
+import { urlPrefix } from "./cells/TitleCell";
 
 interface ThumbnailProps {
     type: "pdb" | "emdb";
@@ -12,16 +13,23 @@ interface ThumbnailProps {
 }
 
 export const Thumbnail: React.FC<ThumbnailProps> = React.memo(props => {
-    const { value, tooltip } = props;
+    const { value, tooltip, type } = props;
     const { imageUrl: imageSrc, id: name } = value;
+    const href = urlPrefix + (type === "emdb" ? value.id.toUpperCase() : value.id.toLowerCase());
 
     return (
         <div style={styles.thumbnailWrapper}>
             <HtmlTooltip title={tooltip}>
-                <img alt={name} src={imageSrc} loading="lazy" style={styles.image} />
+                <a href={href} target="_blank" rel="noreferrer">
+                    <img alt={name} src={imageSrc} loading="lazy" style={styles.image} />
+                </a>
             </HtmlTooltip>
 
-            <p>{name}</p>
+            <p>
+                <a href={href} target="_blank" rel="noreferrer" style={styles.link}>
+                    {name}
+                </a>
+            </p>
 
             {value.externalLinks.map(externalLink => (
                 <BadgeLink

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/LigandsCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/LigandsCell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import i18n from "../../../../utils/i18n";
-import { CellProps, styles } from "../Columns";
+import { BadgeLink } from "../BadgeLink";
+import { CellProps, styles as columnsStyles } from "../Columns";
 import { Link } from "../Link";
 import { Wrapper } from "./Wrapper";
 
@@ -29,7 +30,11 @@ export const LigandsCell: React.FC<CellProps> = React.memo(props => {
                         )}
 
                         {ligand.imageLink && (
-                            <img alt={ligand.id} src={ligand.imageLink} style={styles.image} />
+                            <img
+                                alt={ligand.id}
+                                src={ligand.imageLink}
+                                style={columnsStyles.image}
+                            />
                         )}
                     </React.Fragment>
                 ),
@@ -45,13 +50,23 @@ export const LigandsCell: React.FC<CellProps> = React.memo(props => {
             field="ligands"
         >
             {ligands.map(ligand => (
-                <Link
-                    key={ligand.id}
-                    tooltip={ligand.tooltip}
-                    url={ligand.url}
-                    text={`${ligand.name} (${ligand.id})`}
-                />
+                <>
+                    <Link
+                        key={ligand.id}
+                        tooltip={ligand.tooltip}
+                        url={ligand.url}
+                        text={`${ligand.name} (${ligand.id})`}
+                    />
+                    <BadgeLink style={styles.badgeLink} key={""} url={""} icon="viewer" />
+                </>
             ))}
         </Wrapper>
     );
 });
+
+const styles = {
+    badgeLink: {
+        display: "inline-block",
+        marginLeft: 5,
+    },
+};

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/LigandsCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/LigandsCell.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import i18n from "../../../../utils/i18n";
-import { BadgeLink } from "../BadgeLink";
-import { CellProps, styles as columnsStyles } from "../Columns";
+import { CellProps, styles } from "../Columns";
 import { Link } from "../Link";
 import { Wrapper } from "./Wrapper";
 
@@ -30,11 +29,7 @@ export const LigandsCell: React.FC<CellProps> = React.memo(props => {
                         )}
 
                         {ligand.imageLink && (
-                            <img
-                                alt={ligand.id}
-                                src={ligand.imageLink}
-                                style={columnsStyles.image}
-                            />
+                            <img alt={ligand.id} src={ligand.imageLink} style={styles.image} />
                         )}
                     </React.Fragment>
                 ),
@@ -50,23 +45,13 @@ export const LigandsCell: React.FC<CellProps> = React.memo(props => {
             field="ligands"
         >
             {ligands.map(ligand => (
-                <>
-                    <Link
-                        key={ligand.id}
-                        tooltip={ligand.tooltip}
-                        url={ligand.url}
-                        text={`${ligand.name} (${ligand.id})`}
-                    />
-                    <BadgeLink style={styles.badgeLink} key={""} url={""} icon="viewer" />
-                </>
+                <Link
+                    key={ligand.id}
+                    tooltip={ligand.tooltip}
+                    url={ligand.url}
+                    text={`${ligand.name} (${ligand.id})`}
+                />
             ))}
         </Wrapper>
     );
 });
-
-const styles = {
-    badgeLink: {
-        display: "inline-block",
-        marginLeft: 5,
-    },
-};

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
@@ -3,8 +3,10 @@ import { CellProps } from "../Columns";
 import { BadgeLink } from "../BadgeLink";
 
 export const TitleCell: React.FC<CellProps> = React.memo(props => {
+    const urlPrefix = "/ws/viewer/#/";
     const structure = props.row;
-    const queryLinkToUse = structure.emdb?.queryLink || structure.pdb?.queryLink;
+    const queryLinkToUse =
+        urlPrefix + (structure.emdb?.id.toUpperCase() || structure.pdb?.id.toLowerCase());
 
     return (
         <>

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { CellProps } from "../Columns";
 import { BadgeLink } from "../BadgeLink";
 
+export const urlPrefix = "/ws/viewer/#/";
+
 export const TitleCell: React.FC<CellProps> = React.memo(props => {
-    const urlPrefix = "/ws/viewer/#/";
     const structure = props.row;
     const queryLinkToUse =
         urlPrefix + (structure.emdb?.id.toUpperCase() || structure.pdb?.id.toLowerCase());

--- a/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
+++ b/app/assets/javascripts/covid19/src/webapp/components/structures-table/cells/TitleCell.tsx
@@ -11,7 +11,9 @@ export const TitleCell: React.FC<CellProps> = React.memo(props => {
 
     return (
         <>
-            <div style={styles.title}>{props.row.title}</div>
+            <div style={styles.title}>
+                <a href={queryLinkToUse}>{props.row.title}</a>
+            </div>
 
             <BadgeLink
                 style={styles.badgeLink}

--- a/app/assets/stylesheets/webserver/main.css.scss
+++ b/app/assets/stylesheets/webserver/main.css.scss
@@ -290,6 +290,12 @@ form button {
     margin-top: 18px;
 }
 
+div[data-field="title"] a,
+div[data-field="title"] a:hover {
+    color: inherit;
+    text-decoration: none;
+}
+
 a {
     color: #268bbe;
     text-decoration: none;

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -2,7 +2,7 @@
   %nav#Navbar.navbar.navbar-light.navbar-expand-md.text-sm-center.d-flex
     .container-fluid
       #Logo.d-flex
-        %a.navbar-brand{:href => "#"}
+        %a.navbar-brand{:href => ws_path}
           %img{:height => "72", :src => "/assets/3DBionotesLogo-small.jpg", :style => "height: auto;width: 260px;"}/
         %button.navbar-toggler{"data-target" => "#navcol-1", "data-toggle" => "collapse"}
           %span.sr-only Toggle navigation


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/21w49qu, https://app.clickup.com/t/1yt0c0x, https://app.clickup.com/t/1yt0bxg

### :memo: Implementation

Top left corner now gows to the root path. We were using the queryLink from the data source provided, but now is created with the url prefix and the id of PDB/EMDB. Added link on the img and title in PDB/EMDB cells.
