### PR TITLE
Add help to add annotation and network header modal dialog

### DIFF
--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/DialogTitleHelp.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/DialogTitleHelp.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "styled-components";
+import { DialogTitle, IconButton } from "@material-ui/core";
+import { Close, HelpOutline as HelpOutlineIcon } from "@material-ui/icons";
+import { HtmlTooltip, styles } from "./HtmlTooltip";
+
+interface DialogTitleHelpProps {
+    title: string;
+    onClose: () => void;
+    tooltip: NonNullable<React.ReactNode>;
+}
+
+export const DialogTitleHelp: React.FC<DialogTitleHelpProps> = React.memo(props => {
+    const { title, tooltip, onClose } = props;
+    return (
+        <StyledDialogTitle>
+            {title}
+            <HtmlTooltip title={tooltip}>
+                <span style={styles.tooltip}>
+                    <HelpOutlineIcon />
+                </span>
+            </HtmlTooltip>
+            <IconButton onClick={onClose}>
+                <Close />
+            </IconButton>
+        </StyledDialogTitle>
+    );
+});
+
+const StyledDialogTitle = styled(DialogTitle)`
+    .MuiTypography-root {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 100%;
+        .MuiButtonBase-root.MuiIconButton-root {
+            margin-left: auto;
+        }
+    }
+`;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/HtmlTooltip.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/HtmlTooltip.tsx
@@ -1,0 +1,40 @@
+import { Theme, Typography, withStyles } from "@material-ui/core";
+import { Tooltip } from "@material-ui/core";
+import styled from "styled-components";
+
+export const HtmlTooltip = withStyles((theme: Theme) => ({
+    tooltip: {
+        backgroundColor: "#f5f5f9",
+        color: "rgba(0, 0, 0, 0.87)",
+        maxWidth: 600,
+        fontSize: theme.typography.pxToRem(12),
+        border: "1px solid #dadde9",
+    },
+}))(Tooltip);
+
+export const StyledTypography = styled(Typography)`
+    &.MuiTypography-body2 {
+        font-size: 0.75rem;
+        color: rgba(0, 0, 0, 0.87);
+        word-wrap: break-word;
+        font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+        font-weight: 500;
+    }
+`;
+
+export const styles = {
+    tooltip: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontWeight: 700,
+        height: "45px",
+        width: "45px",
+        margin: "auto 5px",
+        color: "#ffffff",
+        backgroundColor: "#607d8b",
+        borderRadius: "0.75rem",
+        outline: "none",
+        cursor: "pointer",
+    },
+};

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/HtmlTooltip.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/HtmlTooltip.tsx
@@ -12,7 +12,7 @@ export const HtmlTooltip = withStyles((theme: Theme) => ({
     },
 }))(Tooltip);
 
-export const StyledTypography = styled(Typography)`
+export const TooltipTypography = styled(Typography)`
     &.MuiTypography-body2 {
         font-size: 0.75rem;
         color: rgba(0, 0, 0, 0.87);

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
@@ -8,7 +8,7 @@ import {
     IconButton,
     Switch,
 } from "@material-ui/core";
-import { Close } from "@material-ui/icons";
+import { Close, HelpOutline as HelpOutlineIcon } from "@material-ui/icons";
 import i18n from "../../utils/i18n";
 import { useBooleanState } from "../../hooks/use-boolean";
 import { Dropzone, DropzoneRef } from "../dropzone/Dropzone";
@@ -23,6 +23,8 @@ import {
 } from "../../../domain/entities/Annotation";
 import { useAppContext } from "../AppContext";
 import { useCallbackEffect } from "../../hooks/use-callback-effect";
+import { HtmlTooltip, StyledTypography, styles } from "../HtmlTooltip";
+import styled from "styled-components";
 
 export interface AnnotationsToolProps {
     onClose(): void;
@@ -99,12 +101,25 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
 
     return (
         <Dialog open={true} onClose={onClose} maxWidth="lg">
-            <DialogTitle>
+            <StyledDialogTitle>
                 {i18n.t("Add annotation")}
+                <HtmlTooltip
+                    title={
+                        <StyledTypography variant="body2">
+                            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
+                            aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
+                            atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
+                        </StyledTypography>
+                    }
+                >
+                    <span style={styles.tooltip}>
+                        <HelpOutlineIcon />
+                    </span>
+                </HtmlTooltip>
                 <IconButton onClick={onClose}>
                     <Close />
                 </IconButton>
-            </DialogTitle>
+            </StyledDialogTitle>
 
             <DialogContent>
                 <label>
@@ -314,3 +329,15 @@ function getAnnotationsFromAnnotationFromTrack(annotation: AnnotationWithTrack):
     ];
     return { tracks, data: JSON.stringify(annotation) };
 }
+
+export const StyledDialogTitle = styled(DialogTitle)`
+    .MuiTypography-root {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 100%;
+        .MuiButtonBase-root.MuiIconButton-root {
+            margin-left: auto;
+        }
+    }
+`;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
@@ -1,14 +1,6 @@
 import React, { useCallback, useState, useRef } from "react";
 import _ from "lodash";
-import {
-    CircularProgress,
-    Dialog,
-    DialogContent,
-    DialogTitle,
-    IconButton,
-    Switch,
-} from "@material-ui/core";
-import { Close, HelpOutline as HelpOutlineIcon } from "@material-ui/icons";
+import { CircularProgress, Dialog, DialogContent, Switch } from "@material-ui/core";
 import i18n from "../../utils/i18n";
 import { useBooleanState } from "../../hooks/use-boolean";
 import { Dropzone, DropzoneRef } from "../dropzone/Dropzone";
@@ -23,8 +15,8 @@ import {
 } from "../../../domain/entities/Annotation";
 import { useAppContext } from "../AppContext";
 import { useCallbackEffect } from "../../hooks/use-callback-effect";
-import { HtmlTooltip, StyledTypography, styles } from "../HtmlTooltip";
-import styled from "styled-components";
+import { TooltipTypography } from "../HtmlTooltip";
+import { DialogTitleHelp } from "../DialogTitleHelp";
 
 export interface AnnotationsToolProps {
     onClose(): void;
@@ -101,26 +93,17 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
 
     return (
         <Dialog open={true} onClose={onClose} maxWidth="lg">
-            <StyledDialogTitle>
-                {i18n.t("Add annotation")}
-                <HtmlTooltip
-                    title={
-                        <StyledTypography variant="body2">
-                            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
-                            aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
-                            atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
-                        </StyledTypography>
-                    }
-                >
-                    <span style={styles.tooltip}>
-                        <HelpOutlineIcon />
-                    </span>
-                </HtmlTooltip>
-                <IconButton onClick={onClose}>
-                    <Close />
-                </IconButton>
-            </StyledDialogTitle>
-
+            <DialogTitleHelp
+                title={i18n.t("Add annotation")}
+                onClose={onClose}
+                tooltip={
+                    <TooltipTypography variant="body2">
+                        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
+                        aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
+                        atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
+                    </TooltipTypography>
+                }
+            />
             <DialogContent>
                 <label>
                     {isManual ? (
@@ -329,15 +312,3 @@ function getAnnotationsFromAnnotationFromTrack(annotation: AnnotationWithTrack):
     ];
     return { tracks, data: JSON.stringify(annotation) };
 }
-
-export const StyledDialogTitle = styled(DialogTitle)`
-    .MuiTypography-root {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        width: 100%;
-        .MuiButtonBase-root.MuiIconButton-root {
-            margin-left: auto;
-        }
-    }
-`;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/network/Network.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/network/Network.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { Dialog, DialogContent, DialogTitle, IconButton } from "@material-ui/core";
-import { Close } from "@material-ui/icons";
+import { Dialog, DialogContent, IconButton } from "@material-ui/core";
+import { Close, HelpOutline as HelpOutlineIcon } from "@material-ui/icons";
 import i18n from "../../utils/i18n";
 import "./Network.css";
 import NetworkForm, { NetworkFormProps } from "./NetworkForm";
 import { useGoto } from "../../hooks/use-goto";
+import { HtmlTooltip, StyledTypography, styles } from "../HtmlTooltip";
+import { StyledDialogTitle } from "../annotations-tool/AnnotationsTool";
 
 export interface NetworkProps {
     onClose(): void;
@@ -24,12 +26,25 @@ export const Network: React.FC<NetworkProps> = React.memo(props => {
 
     return (
         <Dialog open={true} onClose={onClose} maxWidth="lg">
-            <DialogTitle>
+            <StyledDialogTitle>
                 {i18n.t("Network")}
+                <HtmlTooltip
+                    title={
+                        <StyledTypography variant="body2">
+                            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
+                            aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
+                            atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
+                        </StyledTypography>
+                    }
+                >
+                    <span style={styles.tooltip}>
+                        <HelpOutlineIcon />
+                    </span>
+                </HtmlTooltip>
                 <IconButton onClick={onClose}>
                     <Close />
                 </IconButton>
-            </DialogTitle>
+            </StyledDialogTitle>
 
             <DialogContent>
                 {i18n.t(

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/network/Network.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/network/Network.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { Dialog, DialogContent, IconButton } from "@material-ui/core";
-import { Close, HelpOutline as HelpOutlineIcon } from "@material-ui/icons";
+import { Dialog, DialogContent } from "@material-ui/core";
 import i18n from "../../utils/i18n";
 import "./Network.css";
 import NetworkForm, { NetworkFormProps } from "./NetworkForm";
 import { useGoto } from "../../hooks/use-goto";
-import { HtmlTooltip, StyledTypography, styles } from "../HtmlTooltip";
-import { StyledDialogTitle } from "../annotations-tool/AnnotationsTool";
+import { DialogTitleHelp } from "../DialogTitleHelp";
+import { TooltipTypography } from "../HtmlTooltip";
 
 export interface NetworkProps {
     onClose(): void;
@@ -26,26 +25,17 @@ export const Network: React.FC<NetworkProps> = React.memo(props => {
 
     return (
         <Dialog open={true} onClose={onClose} maxWidth="lg">
-            <StyledDialogTitle>
-                {i18n.t("Network")}
-                <HtmlTooltip
-                    title={
-                        <StyledTypography variant="body2">
-                            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
-                            aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
-                            atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
-                        </StyledTypography>
-                    }
-                >
-                    <span style={styles.tooltip}>
-                        <HelpOutlineIcon />
-                    </span>
-                </HtmlTooltip>
-                <IconButton onClick={onClose}>
-                    <Close />
-                </IconButton>
-            </StyledDialogTitle>
-
+            <DialogTitleHelp
+                title={i18n.t("Network")}
+                onClose={onClose}
+                tooltip={
+                    <TooltipTypography variant="body2">
+                        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur eaque
+                        aspernatur, adipisci harum dolor neque dicta voluptas a asperiores sequi
+                        atque quibusdam cumque. At excepturi nobis ea, tempora omnis eum
+                    </TooltipTypography>
+                }
+            />
             <DialogContent>
                 {i18n.t(
                     "In order to calculate Protein-protein interaction networks, please select the species and provide a list of protein identifiers."


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/1xwfh93

### :memo: Implementation

Added help icon with tooltip on hover in "add annotation" and "network" header modal dialog.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/43061485/159437981-3dfd2e96-ca4d-490f-8d48-f2865e6e0a8c.png)
![image](https://user-images.githubusercontent.com/43061485/159438036-424cafe9-d115-4ac9-94e9-ea123922d264.png)