### PR TITLE
Fix tooltip track not showing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,10 @@
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap";
+
+protvista-tooltip table.tooltip {
+    position: revert;
+    display: revert;
+    font-family: Verdana, Arial, sans-serif; //from protvista
+    line-height: normal;
+    opacity: revert;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,6 @@
 protvista-tooltip table.tooltip {
     position: revert;
     display: revert;
-    font-family: Verdana, Arial, sans-serif; //from protvista
     line-height: normal;
     opacity: revert;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,5 @@
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap";
-
 protvista-tooltip table.tooltip {
     position: revert;
     display: revert;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865ctgkrf

### :memo: Fix

`app/assets/stylesheets/application.scss` imports bootstrap and overrides protvista `.tooltip` styles; so this solution should revert the bootstrap changes (except the familiar font which is a nice change from bootstrap part)👍