### PR TITLE
Selective camera reset and highlight

### DIFF
--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/RootViewerContents.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/RootViewerContents.tsx
@@ -2,7 +2,7 @@ import _ from "lodash";
 import React from "react";
 import styled from "styled-components";
 import { ResizableBox, ResizableBoxProps, ResizeCallbackData } from "react-resizable";
-import { Fab, IconButton } from "@material-ui/core";
+import { Fab } from "@material-ui/core";
 import { KeyboardArrowUp as KeyboardArrowUpIcon } from "@material-ui/icons";
 import { Viewers } from "./viewers/Viewers";
 import { MolecularStructure } from "./molecular-structure/MolecularStructure";

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
@@ -4,6 +4,7 @@ import { InitParams } from "@3dbionotes/pdbe-molstar/lib/spec";
 import { PDBeMolstarPlugin } from "@3dbionotes/pdbe-molstar/lib";
 import { LoadParams } from "@3dbionotes/pdbe-molstar/lib/helpers";
 import {
+    BaseSelection,
     DbItem,
     diffDbItems,
     emptySelection,
@@ -81,6 +82,8 @@ function usePdbePlugin(options: MolecularStructureProps) {
     const [pluginLoad, setPluginLoad] = React.useState<Date>();
     const pdbePlugin = pdbePlugin0 && pluginLoad ? pdbePlugin0 : undefined;
     const molstarState = React.useRef<MolstarState>({ type: "pdb", items: [], chainId: undefined });
+    const chainId = newSelection.chainId;
+    const ligandId = newSelection.ligandId;
     debugVariable({ molstarState });
 
     // Keep a reference containing the previous value of selection. We need this value to diff
@@ -102,10 +105,16 @@ function usePdbePlugin(options: MolecularStructureProps) {
             onLigandsLoaded(ligands);
         }
 
-        //the line below should be unnecessary as setVisbility is added on each item on load
-        // setVisibilityForSelection(pdbePlugin, newSelection);
-        highlight(pdbePlugin, chains, newSelection, molstarState);
-    }, [pluginLoad, pdbePlugin, onLigandsLoaded, newSelection, chains]);
+        const currentSelection = prevSelectionRef.current || emptySelection;
+        if (newSelection.chainId !== currentSelection.chainId) {
+            highlight(pdbePlugin, chains, newSelection, molstarState);
+        }
+    }, [pluginLoad, pdbePlugin, onLigandsLoaded, newSelection, chains, prevSelectionRef]);
+
+    React.useEffect(() => {
+        if (!pluginLoad || !pdbePlugin) return;
+        highlight(pdbePlugin, chains, { chainId, ligandId }, molstarState, false);
+    }, [pluginLoad, prevSelectionRef, chains, chainId, ligandId, pdbePlugin]);
 
     const pluginRef = React.useCallback(
         async (element: HTMLDivElement | null) => {
@@ -148,10 +157,10 @@ function usePdbePlugin(options: MolecularStructureProps) {
                                 console.debug("molstar.events.loadComplete", loaded);
                                 if (loaded) {
                                     setPluginLoad(new Date());
+                                    // On FF, the canvas sometimes shows a black box. Resize the viewport to force a redraw
+                                    window.dispatchEvent(new Event("resize"));
                                     resolve();
                                 } else reject("PDB molstar did not load");
-                                // On FF, the canvas sometimes shows a black box. Resize the viewport to force a redraw
-                                window.dispatchEvent(new Event("resize"));
                             },
                             error: err => {
                                 console.error(err);
@@ -255,16 +264,25 @@ function usePdbePlugin(options: MolecularStructureProps) {
                 /* Refined added/removed/updated are only valid models and when there is a change on them.
                 Changes on not valid models will not trigger applySelectionChangesToPlugin() but on setSelection()
                 to remove unvalid ones*/
-                //prettier-ignore
-                if (!( _.isEmpty(refinedAdded) && _.isEmpty(refinedRemoved) && _.isEmpty(refinedUpdated)))
-                    updateLoader("updateVisualPlugin",applySelectionChangesToPlugin(
-                        pdbePlugin,
-                        molstarState,
-                        chains,
-                        currentSelection,
-                        refinedNewSelection,
-                        updateLoader
-                    ));
+
+                const hasChanges = !(
+                    _.isEmpty(refinedAdded) &&
+                    _.isEmpty(refinedRemoved) &&
+                    _.isEmpty(refinedUpdated)
+                );
+
+                if (hasChanges)
+                    updateLoader(
+                        "updateVisualPlugin",
+                        applySelectionChangesToPlugin(
+                            pdbePlugin,
+                            molstarState,
+                            chains,
+                            currentSelection,
+                            refinedNewSelection,
+                            updateLoader
+                        )
+                    );
                 setSelection(refinedNewSelection);
             });
         }
@@ -519,22 +537,25 @@ async function applySelectionChangesToPlugin(
         highlight(plugin, chains, newSelection, molstarState);
     }
 
-    plugin.visual.reset({ camera: true });
+    if (added.length + removed.length > 0) {
+        plugin.visual.reset({ camera: true });
+    }
 }
 
 async function highlight(
     plugin: PDBeMolstarPlugin,
     chains: Maybe<PdbInfo["chains"]>,
-    selection: Selection,
-    molstarState: MolstarStateRef
+    selection: BaseSelection,
+    molstarState: MolstarStateRef,
+    focus = true
 ): Promise<void> {
     plugin.visual.clearSelection().catch(_err => {});
     plugin.visual.clearHighlight().catch(_err => {}); //remove previous highlight
     const ligandsView = getLigandView(selection);
     if (ligandsView) return;
 
-    const chain = getSelectedChain(chains, selection);
     const chainId = selection.chainId;
+    const chain = getSelectedChain(chains, chainId);
     molstarState.current = MolstarStateActions.setChain(molstarState.current, chainId);
 
     if (!chain) return;
@@ -545,7 +566,7 @@ async function highlight(
                 {
                     struct_asym_id: chain.chainId,
                     color: "#0000ff",
-                    focus: true,
+                    focus,
                 },
             ],
             structureNumber: 1, //rooting to the main PDB
@@ -586,7 +607,7 @@ function getPdbePluginInitParams(_plugin: PDBeMolstarPlugin, newSelection: Selec
     };
 }
 
-function getLigandView(selection: Selection): LigandView | undefined {
+function getLigandView(selection: BaseSelection): LigandView | undefined {
     const { chainId, ligandId } = selection;
     if (!chainId || !ligandId) return;
     const [component, position] = ligandId.split("-");

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/protvista/ProtvistaViewer.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/protvista/ProtvistaViewer.tsx
@@ -35,10 +35,10 @@ export const ProtvistaViewer: React.FC<ProtvistaViewerProps> = props => {
         [setBlockVisibility]
     );
 
-    const selectedChain = React.useMemo(() => getSelectedChain(pdbInfo?.chains, selection), [
-        pdbInfo,
-        selection,
-    ]);
+    const selectedChain = React.useMemo(
+        () => getSelectedChain(pdbInfo?.chains, selection.chainId),
+        [pdbInfo, selection]
+    );
 
     const ligandsAndSmallMoleculesCount = React.useMemo(
         () =>

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/viewer-selector/ViewerSelector.css
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/viewer-selector/ViewerSelector.css
@@ -57,6 +57,12 @@
     padding: 6px;
 }
 
+.db-item-main .MuiIconButton-root:hover {
+    background: #ababab;
+    color: #fff;
+    padding: 6px;
+}
+
 .db-item-main .label-main .label {
     color: #123546;
     font-weight: 700;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/viewer-selector/ViewerSelector.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/viewer-selector/ViewerSelector.tsx
@@ -151,7 +151,7 @@ function useChainDropdown(options: ViewerSelectorProps): DropdownProps {
         [pdbInfo]
     );
 
-    const selectedChain = getSelectedChain(pdbInfo?.chains, selection);
+    const selectedChain = getSelectedChain(pdbInfo?.chains, selection.chainId);
 
     const text = expanded
         ? selectedChain
@@ -162,8 +162,8 @@ function useChainDropdown(options: ViewerSelectorProps): DropdownProps {
     return { text, items, selected: selectedChain?.chainId, onClick: setChain };
 }
 
-export function getSelectedChain(chains: PdbInfo["chains"] | undefined, selection: Selection) {
-    return chains?.find(chain => chain.chainId === selection.chainId) || chains?.[0];
+export function getSelectedChain(chains: PdbInfo["chains"] | undefined, chainId: Maybe<string>) {
+    return chains?.find(chain => chain.chainId === chainId) || chains?.[0];
 }
 
 function useLigandsDropdown(options: ViewerSelectorProps): DropdownProps {
@@ -177,7 +177,7 @@ function useLigandsDropdown(options: ViewerSelectorProps): DropdownProps {
         [selection, onSelectionChange, pdbInfo]
     );
 
-    const selectedChain = getSelectedChain(pdbInfo?.chains, selection);
+    const selectedChain = getSelectedChain(pdbInfo?.chains, selection.chainId);
 
     const items: DropdownProps["items"] = React.useMemo(() => {
         return pdbInfo?.ligands


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865czeybf

### :memo: Implementation

The setVisibility was a bit buggy with zoom in zoom out and the flash colors. The camera reset is only applied now when there are actually models added or deleted or in the first glance when the plugin is started because an EMDB or a validation model such as PDB-Redo are indirectly added. Now setVisibility does not reset the camera or focus on the chain; and the focus of the chain is done when the chain is really changed.