### PR TITLE
Fix start / end value on tool: Upload custom annotations

### DIFF
--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.css
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.css
@@ -36,6 +36,11 @@ label {
     /* box-shadow: 0 0 0 0.2rem rgba(0 123 255 0.25); */
 }
 
+.form-control-viewer.form-control-color {
+    padding: 0 0.125em;
+    width: 30px;
+}
+
 .submitButton {
     border-radius: 0.25rem;
     margin: 0.5rem 0;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/annotations-tool/AnnotationsTool.tsx
@@ -206,21 +206,16 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
                         />
 
                         <label htmlFor="color">{i18n.t("Color")}</label>
-                        <small>
-                            {i18n.t(
-                                "You can put a color name (ie. red) or color hex value (ie. #ffffff)"
-                            )}{" "}
-                        </small>
 
                         <input
                             aria-label={i18n.t("Color")}
                             id="color"
-                            type="text"
+                            type="color"
                             value={annotationForm.color}
                             onChange={e =>
                                 setAnnotationForm({ ...annotationForm, color: e.target.value })
                             }
-                            className="form-control-viewer"
+                            className="form-control-viewer form-control-color"
                         />
 
                         <label htmlFor="index">{i18n.t("Index")}</label>
@@ -265,7 +260,7 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
                             aria-label={i18n.t("Starting value")}
                             id="start"
                             type="number"
-                            value={annotationForm.start}
+                            value={annotationForm.start === 0 ? "" : annotationForm.start}
                             onChange={e =>
                                 setAnnotationForm({
                                     ...annotationForm,
@@ -280,7 +275,7 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
                             aria-label={i18n.t("Ending value")}
                             id="end"
                             type="number"
-                            value={annotationForm.end}
+                            value={annotationForm.end === 0 ? "" : annotationForm.end}
                             onChange={e =>
                                 setAnnotationForm({
                                     ...annotationForm,
@@ -331,14 +326,19 @@ export const AnnotationsTool: React.FC<AnnotationsToolProps> = React.memo(props 
 
 const Form: React.FC<{ isDisabled: boolean }> = props => {
     const { isDisabled, children } = props;
+
     return (
-        <form className="annotationForm">
+        <form className="annotationForm" onSubmit={preventSubmit}>
             <fieldset style={{ border: "none" }} disabled={isDisabled}>
                 {children}
             </fieldset>
         </form>
     );
 };
+
+function preventSubmit(ev: React.FormEvent<HTMLFormElement>) {
+    ev.preventDefault();
+}
 
 const dialogStyles = recordOfStyles({
     actionButtons: {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693cnw8a

### :memo: Implementation

Previously, the value on the inputs didn't allow to remove the leading zero. That scenario has been fixed.
Also, the color input has been changed to a color picker.

### :art: Screenshots

![image](https://github.com/EyeSeeTea/3DBIONOTES/assets/43061485/d2addc62-84f6-46ca-964a-0a30d4f570f8)