### PR TITLE
Fix pdbe-molstar not loading correctly after exiting ligands view

### DIFF
--- a/app/assets/javascripts/3dbio_viewer/public/index.html
+++ b/app/assets/javascripts/3dbio_viewer/public/index.html
@@ -18,7 +18,7 @@
         />
 
         <script src="/protvista-pdb/protvista-pdb-2.0.1-estv1.js"></script>
-        <script src="/pdbe-molstar/pdbe-molstar-plugin-3.1.0-est-1.js"></script>
+        <script src="/pdbe-molstar/pdbe-molstar-plugin-3.1.0-est-2-beta.1.js"></script>
 
         <title>3dbio Viewer</title>
     </head>

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
@@ -107,7 +107,7 @@ function usePdbePlugin(options: MolecularStructureProps) {
     const [prevSelectionRef, setPrevSelection] = useReference<Selection>();
 
     debugVariable({ pdbePlugin });
-    const chains = options.pdbInfo?.chains;
+    const chains = React.useMemo(() => options.pdbInfo?.chains ?? [], [options.pdbInfo?.chains]);
 
     const [uploadDataToken, extension] =
         newSelection.type === "uploadData" ? [newSelection.token, newSelection.extension] : [];
@@ -134,6 +134,7 @@ function usePdbePlugin(options: MolecularStructureProps) {
     const pluginRef = React.useCallback(
         async (element: HTMLDivElement | null) => {
             if (!element) return;
+            if (_.isEmpty(chains)) return;
             const currentSelection = prevSelectionRef.current;
             const pluginAlreadyRendered = Boolean(pdbePlugin);
             const ligandChanged =
@@ -259,6 +260,7 @@ function usePdbePlugin(options: MolecularStructureProps) {
             updateLoader,
             extension,
             uploadDataToken,
+            chains,
         ]
     );
 

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/MolecularStructure.tsx
@@ -149,8 +149,26 @@ function usePdbePlugin(options: MolecularStructureProps) {
 
             // To subscribe to the load event: plugin.events.loadComplete.subscribe(loaded => { ... });
             if (pluginAlreadyRendered) {
+                //When ligand has changed
                 molstarState.current = MolstarStateActions.fromInitParams(initParams, newSelection);
                 await updateLoader("updateVisualPlugin", plugin.visual.update(initParams));
+                if (newSelection.ligandId === undefined && newSelection.type === "free") {
+                    const plainSelection = {
+                        ...emptySelection,
+                        main: { pdb: newSelection.main.pdb, emdb: undefined },
+                    };
+                    await updateLoader(
+                        "updateVisualPlugin",
+                        applySelectionChangesToPlugin(
+                            plugin,
+                            molstarState,
+                            chains,
+                            plainSelection,
+                            newSelection,
+                            updateLoader
+                        )
+                    );
+                }
             } else if (!mainPdb && emdbId)
                 updateLoader(
                     "getRelatedPdbModel",

--- a/app/views/webserver/viewer.html.haml
+++ b/app/views/webserver/viewer.html.haml
@@ -7,7 +7,7 @@
 = stylesheet_link_tag("https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css")
 
 -# PDBE Molstar
-= javascript_include_tag('3dbio_viewer/build/pdbe-molstar/pdbe-molstar-plugin-3.1.0-est-1.js')
+= javascript_include_tag('3dbio_viewer/build/pdbe-molstar/pdbe-molstar-plugin-3.1.0-est-2-beta.1.js')
 
 = javascript_include_tag('3dbio_viewer/build/app/2.chunk.js')
 = javascript_include_tag('3dbio_viewer/build/app/main.chunk.js')


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865d2m9hu

### :memo: Implementation

Previously, after exiting the ligands view, every model (except the main PDB) wouldn't be added to Molstar canvas. Also, the ligand selector would be removed. This behavior was not happening because some strange `useEffect` was causing ligands to be empty `[ ]`, but instead, because the method used when updating Molstar was only happening when the ligand was changed: it only was loading the main PDB and also with the default label; that's why when reading the structure tree, ligands wouldn't be found.

That behavior has been changed by forcing the plugin to update visually again and specifying the additional models. And also changing the method to specify the label of the main PDB.

PR on pdbe-molstar: [#10](https://github.com/EyeSeeTea/pdbe-molstar/pull/10)