### PR TITLE
Fix zombie processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 3DBIONOTES-WS v3.12.0
+# 3DBIONOTES-WS v3.12.1
 
 ## Integrating molecular biology
 

--- a/app/assets/javascripts/3dbio_viewer/package.json
+++ b/app/assets/javascripts/3dbio_viewer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "3dbio-viewer",
-    "version": "3.12.0",
+    "version": "3.12.1",
     "private": true,
     "dependencies": {
         "@3dbionotes/pdbe-molstar": "3.1.0-est-4",

--- a/app/assets/javascripts/covid19/package.json
+++ b/app/assets/javascripts/covid19/package.json
@@ -1,7 +1,7 @@
 {
     "name": "covid19",
     "description": "3dbionotes COVID-19",
-    "version": "3.12.0",
+    "version": "3.12.1",
     "homepage": ".",
     "dependencies": {
         "@dhis2/d2-i18n": "1.0.6",

--- a/app/controllers/run_molprobity_controller.rb
+++ b/app/controllers/run_molprobity_controller.rb
@@ -6,6 +6,11 @@ class RunMolprobityController < ApplicationController
   LocalScripts = Settings.GS_LocalScripts
   LocalMolProobity_tmp = Settings.GS_LocalMolProobity_tmp
 
+  def run(command)
+    pid = spawn(command)
+    Process.detach(pid)
+  end
+
   def get
     suffix = params[:name]
     data = nil
@@ -29,13 +34,13 @@ class RunMolprobityController < ApplicationController
       out = {'status'=>'running', 'id'=>suffix}
       if not File.exist?(directory)
         if suffix =~ /^\d{1}\w{3}$/ and suffix !~ /^\d{4}$/ then
-          system( LocalScripts+"/python3_run_molprobity "+suffix+" &" )
+          run( LocalScripts+"/python3_run_molprobity "+suffix)
         elsif suffix =~ /interactome3d:/ then
           FileUtils.mkdir_p directory
-          system( LocalScripts+"/run_molprobity "+i3d_pdb+" interactome3d >"+directory+"/stdout &>"+directory+"/stderr &")
+          run( LocalScripts+"/run_molprobity "+i3d_pdb+" interactome3d >"+directory+"/stdout &>"+directory+"/stderr")
         else
           Dir.mkdir(directory)
-          system( LocalScripts+"/run_molprobity "+suffix+" local >"+directory+"/stdout &>"+directory+"/stderr &")
+          run( LocalScripts+"/run_molprobity "+suffix+" local >"+directory+"/stdout &>"+directory+"/stderr")
         end
       else
         if File.exist?(directory+'/done') then


### PR DESCRIPTION
There were some zombie processes that were generated by using "[...script] &" on `/compute/molprobity` endpoint while executing `python3_run_molprobity`. We changed that to use `Process.detach` instead, to avoid creating zombie processes.