### PR TITLE
[Viewer] Enhance Molstar state management by improving code readability

### DIFF
--- a/app/assets/javascripts/3dbio_viewer/src/data/RefinedModels.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/data/RefinedModels.ts
@@ -1,4 +1,4 @@
-import { Codec, enumeration, exactly, GetType, string } from "purify-ts";
+import { Codec, enumeration, exactly, GetType, nullable, string } from "purify-ts";
 import { refinedMethods, RefinedModelType } from "../domain/entities/RefinedModel";
 import _ from "lodash";
 import { getKeys } from "../utils/ts-utils";
@@ -6,7 +6,7 @@ import { getKeys } from "../utils/ts-utils";
 export const refinedModelCodec = Codec.interface({
     source: exactly("CERES", "CSTF", "PDB-REDO"),
     method: enumeration(refinedMethods),
-    filename: string,
+    filename: nullable(string),
     externalLink: string,
     details: string, // ""
 });

--- a/app/assets/javascripts/3dbio_viewer/src/data/RefinedModels.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/data/RefinedModels.ts
@@ -1,14 +1,7 @@
 import { Codec, enumeration, exactly, GetType, string } from "purify-ts";
-import { RefinedModelType } from "../domain/entities/RefinedModel";
+import { refinedMethods, RefinedModelType } from "../domain/entities/RefinedModel";
 import _ from "lodash";
 import { getKeys } from "../utils/ts-utils";
-
-enum refinedMethods {
-    pdbRedo = "PDB-Redo",
-    isolde = "Isolde",
-    refmac = "Refmac",
-    phenix = "PHENIX",
-}
 
 export const refinedModelCodec = Codec.interface({
     source: exactly("CERES", "CSTF", "PDB-REDO"),

--- a/app/assets/javascripts/3dbio_viewer/src/data/repositories/RefinedModelApiRepository.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/data/repositories/RefinedModelApiRepository.ts
@@ -1,5 +1,5 @@
 import { FutureData } from "../../domain/entities/FutureData";
-import { RefinedModel } from "../../domain/entities/RefinedModel";
+import { refinedMethods, RefinedModel } from "../../domain/entities/RefinedModel";
 import {
     refinedModelArgsToString,
     RefinedModelGetArgs,
@@ -58,11 +58,4 @@ export class RefinedModelApiRepository implements RefinedModelRepository {
 
         return refinedModels$;
     }
-}
-
-enum refinedMethods {
-    pdbRedo = "PDB-Redo",
-    isolde = "Isolde",
-    refmac = "Refmac",
-    phenix = "PHENIX",
 }

--- a/app/assets/javascripts/3dbio_viewer/src/data/repositories/RefinedModelApiRepository.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/data/repositories/RefinedModelApiRepository.ts
@@ -48,7 +48,7 @@ export class RefinedModelApiRepository implements RefinedModelRepository {
                         source: coincidence.source,
                         method: mapRefinedModelMethod(coincidence.method),
                         externalLink: coincidence.externalLink,
-                        filenameUrl: coincidence.filename.replaceAll(
+                        filenameUrl: coincidence.filename?.replaceAll(
                             "https://cci.lbl.gov/static/data/",
                             "/cci/"
                         ),

--- a/app/assets/javascripts/3dbio_viewer/src/data/storage-cache.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/data/storage-cache.ts
@@ -8,6 +8,11 @@ export function hashUrl(url: string): string {
 }
 
 export function getStorageCache<Data>(key: string): Maybe<Data> {
+    if (localStorage.getItem("disableCache") === "true") {
+        console.debug("Cache is disabled, returning undefined for key:", key);
+        return undefined;
+    }
+
     const cached = localStorage.getItem(key);
     if (!cached) return undefined;
 
@@ -32,6 +37,11 @@ export function getStorageCache<Data>(key: string): Maybe<Data> {
 }
 
 export function setStorageCache<Data>(key: string, value: Data): void {
+    if (localStorage.getItem("disableCache") === "true") {
+        console.debug("Cache is disabled, not setting value for key:", key);
+        return undefined;
+    }
+
     const cacheEntry = {
         value,
         timestamp: Date.now(),

--- a/app/assets/javascripts/3dbio_viewer/src/domain/entities/PdbInfo.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/domain/entities/PdbInfo.ts
@@ -9,11 +9,11 @@ import { MappingChain } from "../../data/repositories/BionotesPdbInfoRepository"
 export interface PdbInfo {
     id: Maybe<string>;
     emdbs: Emdb[];
-    chains: Chain[];
+    chains: PdbChain[];
     ligands: Ligand[];
 }
 
-type Chain = {
+export type PdbChain = {
     id: string;
     name: string;
     shortName: string;
@@ -93,6 +93,6 @@ export function getPdbInfoFromUploadData(uploadData: UploadData): PdbInfo {
 }
 
 // Default chain: the first one with uniprot, or the first one if none has uniprot
-export function getDefaultChain(chains: Chain[]): Maybe<Chain> {
+export function getDefaultChain(chains: PdbChain[]): Maybe<PdbChain> {
     return chains.find(chain => chain.protein) || chains[0];
 }

--- a/app/assets/javascripts/3dbio_viewer/src/domain/entities/RefinedModel.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/domain/entities/RefinedModel.ts
@@ -13,3 +13,10 @@ export type RefinedModel = {
 export function typeIsRefinedModelType(type: string): type is RefinedModelType {
     return refinedModelsType.includes(type as RefinedModelType);
 }
+
+export enum refinedMethods {
+    pdbRedo = "PDB-Redo",
+    isolde = "Isolde",
+    refmac = "Refmac",
+    phenix = "PHENIX",
+}

--- a/app/assets/javascripts/3dbio_viewer/src/domain/entities/RefinedModel.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/domain/entities/RefinedModel.ts
@@ -1,10 +1,11 @@
+import { Maybe } from "../../utils/ts-utils";
 import { SourceName } from "./Source";
 
 export const refinedModelsType = ["pdbRedo", "isolde", "refmac", "phenix"] as const;
 export type RefinedModelType = typeof refinedModelsType[number];
 
 export type RefinedModel = {
-    filenameUrl: string;
+    filenameUrl: Maybe<string>; // Some model files might not be available per failed jobs
     method: RefinedModelType;
     source: SourceName;
     externalLink: string;

--- a/app/assets/javascripts/3dbio_viewer/src/domain/repositories/RefinedModelRepository.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/domain/repositories/RefinedModelRepository.ts
@@ -1,6 +1,6 @@
 import { Maybe } from "../../utils/ts-utils";
 import { FutureData } from "../entities/FutureData";
-import { RefinedModel, RefinedModelType } from "../entities/RefinedModel";
+import { refinedMethods, RefinedModel, RefinedModelType } from "../entities/RefinedModel";
 
 export interface RefinedModelRepository {
     getBy(args: RefinedModelGetArgs): FutureData<RefinedModel>;
@@ -13,4 +13,6 @@ export interface RefinedModelGetArgs {
 }
 
 export const refinedModelArgsToString = (args: RefinedModelGetArgs) =>
-    `${[args.pdbId, args.emdbId, args.method].filter(Boolean).join(", ")}`;
+    `${[refinedMethods[args.method], args.pdbId, args.emdbId ? `EMD-${args.emdbId}` : undefined]
+        .filter(Boolean)
+        .join(", ")}`;

--- a/app/assets/javascripts/3dbio_viewer/src/domain/utils/i18n.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/domain/utils/i18n.ts
@@ -6,4 +6,8 @@ const i18nWrapper = {
     },
 };
 
+export type I18N = {
+    t: (s: string, namespace?: object) => string;
+};
+
 export default i18nWrapper;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
@@ -4,25 +4,26 @@ import { RefinedModelType } from "../../../domain/entities/RefinedModel";
 import { RefinedModelGetArgs } from "../../../domain/repositories/RefinedModelRepository";
 import { DbItem, getRefinedModelIds } from "../../view-models/Selection";
 import { checkModelUrl } from "./usePdbPluginHelpers";
+import { isDev } from "../../../routes";
 
 export class ExternalModel {
     constructor(private compositionRoot: CompositionRoot) {}
 
     // Arrow function -> Safe use of "this" if the method is used as a callback
-    getRefinedModelUrl = (args: RefinedModelGetArgs): Promise<string> => {
+    getRefinedModelUrl = async (args: RefinedModelGetArgs): Promise<string> => {
         return this.compositionRoot.getRefinedModel
             .execute(args)
             .map(refinedModel => refinedModel.filenameUrl)
             .toPromise()
             .then(url => {
-                if (!this.refinedModelUrlIsValidUrl(url)) {
+                if (!url) return Promise.reject(new Error("Refined model URL is not available"));
+                else if (!this.refinedModelUrlIsValidUrl(url))
                     return Promise.reject(new Error("Invalid refined model URL"));
-                }
-                return url;
+                else return url;
             });
     };
 
-    filterOnlyValidRefinedModels(args: {
+    async filterOnlyValidRefinedModels(args: {
         refinedModels: DbItem<RefinedModelType>[];
         onUrlRetrievalFailure: (args: RefinedModelGetArgs) => void;
         onFetchFailure: (args: RefinedModelGetArgs) => void;
@@ -35,7 +36,7 @@ export class ExternalModel {
         }).then(results => _.compact(results));
     }
 
-    private validateRefinedModels(args: {
+    private async validateRefinedModels(args: {
         refinedModels: DbItem<RefinedModelType>[];
         onUrlRetrievalFailure: (args: RefinedModelGetArgs) => void;
         onFetchFailure: (args: RefinedModelGetArgs) => void;
@@ -55,6 +56,8 @@ export class ExternalModel {
     }
 
     private refinedModelUrlIsValidUrl(url: string): boolean {
+        const cciProxiedUrl = /^\/cci\/[^\s]*$/i.test(url);
+        if (isDev && cciProxiedUrl) return true; // In dev mode, allow CCI proxied URLs
         return /^https?:\/\/[^\s/$.?#].[^\s]*$/i.test(url);
     }
 

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
@@ -13,7 +13,13 @@ export class ExternalModel {
         return this.compositionRoot.getRefinedModel
             .execute(args)
             .map(refinedModel => refinedModel.filenameUrl)
-            .toPromise();
+            .toPromise()
+            .then(url => {
+                if (!this.refinedModelUrlIsValidUrl(url)) {
+                    return Promise.reject(new Error("Invalid refined model URL"));
+                }
+                return url;
+            });
     };
 
     filterOnlyValidRefinedModels(args: {
@@ -46,6 +52,10 @@ export class ExternalModel {
         return Promise.allSettled(promises).then(results =>
             results.map(result => (result.status === "fulfilled" ? result.value : false))
         );
+    }
+
+    private refinedModelUrlIsValidUrl(url: string): boolean {
+        return /^https?:\/\/[^\s/$.?#].[^\s]*$/i.test(url);
     }
 
     private async validateRefinedModel(args: {

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/ExternalModel.ts
@@ -1,0 +1,84 @@
+import _ from "lodash";
+import { CompositionRoot } from "../../../compositionRoot";
+import { RefinedModelType } from "../../../domain/entities/RefinedModel";
+import { RefinedModelGetArgs } from "../../../domain/repositories/RefinedModelRepository";
+import { DbItem, getRefinedModelIds } from "../../view-models/Selection";
+import { checkModelUrl } from "./usePdbPluginHelpers";
+
+export class ExternalModel {
+    constructor(private compositionRoot: CompositionRoot) {}
+
+    // Arrow function -> Safe use of "this" if the method is used as a callback
+    getRefinedModelUrl = (args: RefinedModelGetArgs): Promise<string> => {
+        return this.compositionRoot.getRefinedModel
+            .execute(args)
+            .map(refinedModel => refinedModel.filenameUrl)
+            .toPromise();
+    };
+
+    filterOnlyValidRefinedModels(args: {
+        refinedModels: DbItem<RefinedModelType>[];
+        onUrlRetrievalFailure: (args: RefinedModelGetArgs) => void;
+        onFetchFailure: (args: RefinedModelGetArgs) => void;
+    }): Promise<DbItem<RefinedModelType>[]> {
+        const { refinedModels, onUrlRetrievalFailure, onFetchFailure } = args;
+        return this.validateRefinedModels({
+            refinedModels,
+            onUrlRetrievalFailure,
+            onFetchFailure,
+        }).then(results => _.compact(results));
+    }
+
+    private validateRefinedModels(args: {
+        refinedModels: DbItem<RefinedModelType>[];
+        onUrlRetrievalFailure: (args: RefinedModelGetArgs) => void;
+        onFetchFailure: (args: RefinedModelGetArgs) => void;
+    }): Promise<(DbItem<RefinedModelType> | false)[]> {
+        const { refinedModels, onUrlRetrievalFailure, onFetchFailure } = args;
+        const promises = refinedModels.map(model => {
+            return this.validateRefinedModel({
+                model,
+                onUrlRetrievalFailure,
+                onFetchFailure,
+            }).then(valid => (valid ? model : false));
+        });
+
+        return Promise.allSettled(promises).then(results =>
+            results.map(result => (result.status === "fulfilled" ? result.value : false))
+        );
+    }
+
+    private async validateRefinedModel(args: {
+        model: DbItem<RefinedModelType>;
+        onUrlRetrievalFailure: (args: RefinedModelGetArgs) => void;
+        onFetchFailure: (args: RefinedModelGetArgs) => void;
+    }) {
+        const { model, onUrlRetrievalFailure, onFetchFailure } = args;
+        const { pdbId, emdbId } = getRefinedModelIds(model);
+        const modelArgs = {
+            pdbId: pdbId,
+            emdbId: emdbId,
+            method: model.type,
+        };
+
+        const filenameUrl = await this.getRefinedModelUrl(modelArgs).catch(err => {
+            onUrlRetrievalFailure(modelArgs);
+            return Promise.reject(err);
+        });
+
+        const resourceAvailable = await checkModelUrl({
+            id: pdbId,
+            url: filenameUrl,
+        })
+            .then(res => {
+                if (res.loaded) return true;
+                else onFetchFailure(modelArgs);
+            })
+            .catch(err => {
+                onFetchFailure(modelArgs);
+                return Promise.reject(err);
+            });
+
+        return Boolean(resourceAvailable);
+    }
+}

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/PdbMolstarPlugin.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/PdbMolstarPlugin.ts
@@ -1,0 +1,182 @@
+import _ from "lodash";
+import { PDBeMolstarPlugin } from "@3dbionotes/pdbe-molstar/lib";
+import { Maybe } from "../../../utils/ts-utils";
+import { getDefaultChain, PdbChain, PdbInfo } from "../../../domain/entities/PdbInfo";
+import { diffDbItems, getItems, getMainItem, Selection } from "../../view-models/Selection";
+import { getLigands } from "./molstar";
+import { debugVariable } from "../../../utils/debug";
+import { Ligand } from "../../../domain/entities/Ligand";
+import { highlight, MolstarStateRef } from "./usePdbPluginHelpers";
+
+export class PdbMolstarPlugin {
+    constructor(private pdbePlugin: PDBeMolstarPlugin) {}
+
+    getActions(): PdbMolstarActions {
+        return {
+            sequence: {
+                setDefaultChainIfNoIdentifiersAndHasFinishedLoading: (args: {
+                    chainId: Maybe<string>;
+                    ligandId: Maybe<string>;
+                    chains: PdbChain[];
+                }) => this.setDefaultChainInSequenceViewIfNoIdentifiersAndHasFinishedLoading(args),
+                setDefaultChainOnlyOnInit: (args: {
+                    pdbInfo: Maybe<PdbInfo>;
+                    newSelection: Selection;
+                    chainsRef: React.MutableRefObject<PdbChain[]>;
+                    chains: PdbChain[];
+                }) => this.setDefaultChainOnlyOnInitOnSequenceView(args),
+                retrieveAndSetLigands: (args: {
+                    newSelection: Selection;
+                    onLigandsLoaded: (ligands: Ligand[]) => void;
+                }) => this.retrieveAndSetLigands(args),
+            },
+            canvas: {
+                applyHighlight: (args: {
+                    chains: PdbChain[];
+                    chainId: Maybe<string>;
+                    ligandId: Maybe<string>;
+                    molstarState: MolstarStateRef;
+                }) => this.applyHighlight(args),
+            },
+            selection: {
+                hasChanges: (args: { newSelection: Selection; prevSelection: Selection }) =>
+                    this.selectionHasChanges(args),
+            },
+        };
+    }
+
+    setDefaultChainInSequenceViewIfNoIdentifiersAndHasFinishedLoading(args: {
+        chainId: Maybe<string>;
+        ligandId: Maybe<string>;
+        chains: PdbChain[];
+    }) {
+        // Set sequence selected chain
+        const { chainId, ligandId, chains } = args;
+
+        if (_.isEmpty(chains)) return; // If no chain, it's impossible to set a default chain
+
+        // chainId and ligandId are undefined only on init
+        if (chainId === undefined && ligandId === undefined)
+            this.setDefaultChainFromChainsInSequenceView(chains);
+    }
+
+    setDefaultChainOnlyOnInitOnSequenceView(args: {
+        pdbInfo: Maybe<PdbInfo>;
+        newSelection: Selection;
+        chainsRef: React.MutableRefObject<PdbChain[]>;
+        chains: PdbChain[];
+    }) {
+        const { pdbInfo, newSelection, chainsRef, chains } = args;
+        if (!pdbInfo || pdbInfo.id !== getMainItem(newSelection, "pdb")) return;
+
+        // ChainsRef will only be empty on the first initial render
+        if (_.isEmpty(chainsRef.current) && !_.isEmpty(chains)) {
+            this.setDefaultChainFromChainsInSequenceView(chains);
+            chainsRef.current = chains;
+        } else if (!_.isEmpty(chains)) {
+            chainsRef.current = chains;
+        }
+    }
+
+    retrieveAndSetLigands(args: {
+        newSelection: Selection;
+        onLigandsLoaded: (ligands: Ligand[]) => void;
+    }) {
+        const { newSelection, onLigandsLoaded } = args;
+        const ligands = getLigands(this.pdbePlugin, newSelection) || [];
+        debugVariable({ ligands: ligands.length });
+        onLigandsLoaded(ligands);
+    }
+
+    applyHighlight(args: {
+        chains: PdbChain[];
+        chainId: Maybe<string>;
+        ligandId: Maybe<string>;
+        molstarState: MolstarStateRef;
+    }) {
+        const { chains, chainId, ligandId, molstarState } = args;
+
+        highlight({
+            plugin: this.pdbePlugin,
+            chains: chains,
+            selection: {
+                chainId: chainId,
+                ligandId: ligandId,
+            },
+            molstarState: molstarState,
+            focus: false,
+        });
+    }
+
+    selectionHasChanges(args: { newSelection: Selection; prevSelection: Selection }) {
+        const { newSelection, prevSelection } = args;
+        const oldItems = getItems(prevSelection);
+        const newItems = getItems(newSelection);
+        const { added, removed, updated } = diffDbItems(oldItems, newItems);
+
+        return !(_.isEmpty(added) && _.isEmpty(removed) && _.isEmpty(updated));
+    }
+
+    // To be executed when molstar.events.sequenceComplete
+    private setDefaultChainFromChainsInSequenceView(chains: PdbChain[]) {
+        const defaultChainId = getDefaultChain(chains);
+        /*
+             This will propagate back onto the selection state through usePluginRef.setChainThroughMolstar()
+            * as pdbe-molstar/index.ts -> this.events.chainUpdate.next(chainId) -> SequenceView <-- this.props.plugin.events.chainUpdate.subscribe
+            * and it searches for the numeredId of the dropdown for the defaultChainId, and sets it
+            * which will trigger an event through this.setParamProps -> "entity" -> this.updateChainInViewer -> which will call
+            * props.onChainUpdate and that is usePluginRef().setChainThroughMolstar on the viewer
+            */
+        if (defaultChainId) this.setSequenceViewChain(defaultChainId.chainId);
+    }
+
+    private setSequenceViewChain(chainId: string) {
+        this.pdbePlugin.visual.updateChain(chainId);
+    }
+}
+
+type PdbMolstarActions = {
+    sequence: {
+        setDefaultChainIfNoIdentifiersAndHasFinishedLoading: (args: {
+            chainId: Maybe<string>;
+            ligandId: Maybe<string>;
+            chains: PdbChain[];
+        }) => void;
+        setDefaultChainOnlyOnInit: (args: {
+            pdbInfo: Maybe<PdbInfo>;
+            newSelection: Selection;
+            chainsRef: React.MutableRefObject<PdbChain[]>;
+            chains: PdbChain[];
+        }) => void;
+        retrieveAndSetLigands: (args: {
+            newSelection: Selection;
+            onLigandsLoaded: (ligands: Ligand[]) => void;
+        }) => void;
+    };
+    canvas: {
+        applyHighlight: (args: {
+            chains: PdbChain[];
+            chainId: Maybe<string>;
+            ligandId: Maybe<string>;
+            molstarState: MolstarStateRef;
+        }) => void;
+    };
+    selection: {
+        hasChanges: (args: { newSelection: Selection; prevSelection: Selection }) => boolean;
+    };
+};
+
+export const pdbMolstarVoidActions: PdbMolstarActions = {
+    sequence: {
+        setDefaultChainIfNoIdentifiersAndHasFinishedLoading: _.noop,
+        setDefaultChainOnlyOnInit: _.noop,
+        retrieveAndSetLigands: _.noop,
+    },
+    canvas: {
+        applyHighlight: _.noop,
+    },
+    selection: {
+        //to outside
+        hasChanges: () => false,
+    },
+};

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/PluginFeedback.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/PluginFeedback.ts
@@ -1,0 +1,51 @@
+import _ from "lodash";
+import { PDBeMolstarPlugin } from "@3dbionotes/pdbe-molstar/lib";
+import { RefinedModelGetArgs } from "../../../domain/repositories/RefinedModelRepository";
+import { errorsKeys, loaderErrors } from "./usePdbPluginHelpers";
+import { I18N } from "../../../domain/utils/i18n";
+
+//TODO: errors to move here
+export class PluginFeedback {
+    constructor(private pdbePlugin: PDBeMolstarPlugin, private i18n: I18N) {}
+
+    getActions(): PluginFeedbackActions {
+        return {
+            error: {
+                whileRetrievingRefinedModelUrl: (args: RefinedModelGetArgs) =>
+                    this.failureWhileRetrievingRefinedModelUrl(args),
+                whileFetchingRefinedModelUrl: (args: RefinedModelGetArgs) =>
+                    this.failureWhileFetchingRefinedModelUrl(args),
+            },
+        };
+    }
+
+    failureWhileRetrievingRefinedModelUrl(args: RefinedModelGetArgs) {
+        this.pdbePlugin.canvas.showToast({
+            title: this.i18n.t("Error"),
+            message: loaderErrors.refinedModelUnableToFindModelUrl(args),
+            key: errorsKeys.refinedModelUnableToFindModelUrl,
+        });
+    }
+
+    failureWhileFetchingRefinedModelUrl(args: RefinedModelGetArgs) {
+        this.pdbePlugin.canvas.showToast({
+            title: this.i18n.t("Error"),
+            message: loaderErrors.refinedModelUnableToFetch(args),
+            key: errorsKeys.refinedModelUnableToFetch,
+        });
+    }
+}
+
+type PluginFeedbackActions = {
+    error: {
+        whileRetrievingRefinedModelUrl: (args: RefinedModelGetArgs) => void;
+        whileFetchingRefinedModelUrl: (args: RefinedModelGetArgs) => void;
+    };
+};
+
+export const pluginFeedbackVoidActions: PluginFeedbackActions = {
+    error: {
+        whileRetrievingRefinedModelUrl: _.noop,
+        whileFetchingRefinedModelUrl: _.noop,
+    },
+};

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPlugin.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPlugin.ts
@@ -1,13 +1,10 @@
-import React from "react";
 import _ from "lodash";
+import React from "react";
 import { PDBeMolstarPlugin } from "@3dbionotes/pdbe-molstar/lib";
 import {
-    diffDbItems,
     emptySelection,
-    getItems,
     getMainChanges,
     getMainItem,
-    getRefinedModelIds,
     Selection,
     setMainItem,
 } from "../../view-models/Selection";
@@ -15,26 +12,24 @@ import { RefinedModelGetArgs } from "../../../domain/repositories/RefinedModelRe
 import { debugVariable } from "../../../utils/debug";
 import { useReference } from "../../hooks/use-reference";
 import { useAppContext } from "../AppContext";
-import { getLigands } from "./molstar";
-import { getDefaultChain, PdbInfo } from "../../../domain/entities/PdbInfo";
+import { PdbInfo } from "../../../domain/entities/PdbInfo";
 import { routes } from "../../../routes";
 import { MolecularStructureProps } from "./MolecularStructure";
 import { MolstarState } from "./MolstarState";
 import { loaderKeys } from "../RootViewerContents";
 import { usePluginRef } from "./usePluginRef";
+import {
+    applySelectionChangesToPlugin,
+    checkUploadedModelUrl,
+    errorsKeys,
+    loaderErrors,
+} from "./usePdbPluginHelpers";
+import { PdbMolstarPlugin, pdbMolstarVoidActions } from "./PdbMolstarPlugin";
+import { ExternalModel } from "./ExternalModel";
+import { PluginFeedback, pluginFeedbackVoidActions } from "./PluginFeedback";
 import i18n from "../../utils/i18n";
 import "./molstar.css";
 import "./molstar-light.css";
-import {
-    applySelectionChangesToPlugin,
-    checkModelUrl,
-    checkUploadedModelUrl,
-    errorKeyByStatus,
-    errorsKeys,
-    getErrorByStatus,
-    highlight,
-    loaderErrors,
-} from "./usePdbPluginHelpers";
 
 export function usePdbePlugin(options: MolecularStructureProps) {
     const {
@@ -54,9 +49,21 @@ export function usePdbePlugin(options: MolecularStructureProps) {
     const pdbePlugin = pdbePlugin0 && pluginLoad ? pdbePlugin0 : undefined;
     const chainId = newSelection.chainId;
     const ligandId = newSelection.ligandId;
+    const pdbMolstarPlugin = React.useMemo(() => pdbePlugin && new PdbMolstarPlugin(pdbePlugin), [
+        pdbePlugin,
+    ]);
 
     const chains = React.useMemo(() => pdbInfo?.chains ?? [], [pdbInfo?.chains]);
     const chainsRef = React.useRef<PdbInfo["chains"]>([]);
+
+    const externalModel = React.useMemo(
+        () => compositionRoot && new ExternalModel(compositionRoot),
+        [compositionRoot]
+    );
+
+    const pluginFeedback = React.useMemo(() => pdbePlugin && new PluginFeedback(pdbePlugin, i18n), [
+        pdbePlugin,
+    ]);
 
     // Keep a reference containing the previous value of selection. We need this value to diff
     // the new state against the old state and perform imperative operations (add/remove/update)
@@ -65,34 +72,39 @@ export function usePdbePlugin(options: MolecularStructureProps) {
     const [uploadDataToken, extension] =
         newSelection.type === "uploadData" ? [newSelection.token, newSelection.extension] : [];
 
+    // const somePdbInfo= React.useMemo(() => {
+    //     return {
+    //         function: ()=>{},
+    //     }},[]);
+
+    // React.useEffect(() => somePdbInfo.function, [somePdbInfo]);
+
+    const pdbMolstarActions = React.useMemo(
+        () => pdbMolstarPlugin?.getActions() ?? pdbMolstarVoidActions,
+        [pdbMolstarPlugin]
+    );
+
+    const pluginFeedbackActions = React.useMemo(
+        () => pluginFeedback?.getActions() ?? pluginFeedbackVoidActions,
+        [pluginFeedback]
+    );
+
     const setMolstarDefaultChain = React.useCallback(() => {
-        if (!pdbePlugin || _.isEmpty(chains)) return;
-        if (chainId === undefined && ligandId === undefined) {
-            const defaultChainId = getDefaultChain(chains);
-            // This will propagate back onto the selection state through usePluginRef.setChainThroughMolstar()
-            if (defaultChainId) pdbePlugin.visual.updateChain(defaultChainId.chainId);
-        }
-    }, [chainId, chains, ligandId, pdbePlugin]);
+        pdbMolstarActions.sequence.setDefaultChainIfNoIdentifiersAndHasFinishedLoading({
+            chainId: chainId,
+            ligandId: ligandId,
+            chains: chains,
+        });
+    }, [chainId, chains, ligandId, pdbMolstarActions]);
 
-    const setDefaultChainOnlyOnlyOnInitEffect = () => {
-        if (!pdbePlugin || !pdbInfo || pdbInfo.id !== getMainItem(newSelection, "pdb")) return;
-
-        // ChainsRef will only be empty on the first initial render
-        if (_.isEmpty(chainsRef.current) && !_.isEmpty(chains) && pdbePlugin) {
-            const defaultChainId = getDefaultChain(chains);
-            if (defaultChainId) pdbePlugin.visual.updateChain(defaultChainId.chainId);
-            chainsRef.current = chains;
-        } else if (!_.isEmpty(chains)) {
-            chainsRef.current = chains;
-        }
-    };
-
-    React.useEffect(setDefaultChainOnlyOnlyOnInitEffect, [
-        chains,
-        newSelection,
-        pdbInfo,
-        pdbePlugin,
-    ]);
+    React.useEffect(() => {
+        pdbMolstarActions.sequence.setDefaultChainOnlyOnInit({
+            pdbInfo,
+            newSelection,
+            chainsRef,
+            chains,
+        });
+    }, [chains, newSelection, pdbInfo, pdbMolstarActions, pdbePlugin]);
 
     const { pluginRef } = usePluginRef({
         prevSelectionRef,
@@ -112,80 +124,60 @@ export function usePdbePlugin(options: MolecularStructureProps) {
     debugVariable({ molstarState });
     debugVariable({ pdbePlugin });
 
-    function setLigandsFromMolstar() {
-        if (!pluginLoad || !pdbePlugin) return;
-        const ligands = getLigands(pdbePlugin, newSelection) || [];
-        debugVariable({ ligands: ligands.length });
-        onLigandsLoaded(ligands);
-    }
+    React.useEffect(() => {
+        pdbMolstarActions.sequence.retrieveAndSetLigands({
+            newSelection,
+            onLigandsLoaded,
+        });
+    }, [onLigandsLoaded, newSelection, pdbMolstarActions.sequence]);
 
-    function applyHighlight() {
-        if (!pluginLoad || !pdbePlugin) return;
-        highlight(pdbePlugin, chains, { chainId, ligandId }, molstarState, false);
-    }
-
-    React.useEffect(setLigandsFromMolstar, [pluginLoad, pdbePlugin, onLigandsLoaded, newSelection]);
-    React.useEffect(applyHighlight, [
-        pluginLoad,
-        prevSelectionRef,
-        chains,
-        chainId,
-        ligandId,
-        pdbePlugin,
-    ]);
-
-    const getRefinedModelUrl = React.useCallback(
-        (args: RefinedModelGetArgs): Promise<string> => {
-            return compositionRoot.getRefinedModel
-                .execute(args)
-                .map(refinedModel => refinedModel.filenameUrl)
-                .toPromise();
-        },
-        [compositionRoot]
+    React.useEffect(
+        () =>
+            pdbMolstarActions.canvas.applyHighlight({
+                chains: chains,
+                chainId: chainId,
+                ligandId: ligandId,
+                molstarState: molstarState,
+            }),
+        [
+            pluginLoad,
+            prevSelectionRef,
+            chains,
+            chainId,
+            ligandId,
+            pdbePlugin,
+            pdbMolstarActions.canvas,
+        ]
     );
 
-    const updateSelection = React.useCallback(
+    // const getRefinedModelUrl = React.useCallback(
+    //     (args: RefinedModelGetArgs) => externalModel.getRefinedModelUrl(args),
+    //     [externalModel]
+    // );
+
+    const checkSelectionChangesWithRefinedModelUrlCheckingAndTriggerChanges = React.useCallback(
         (currentSelection: Selection, newSelection: Selection) => {
-            if (!pdbePlugin) return;
-            const oldItems = getItems(currentSelection);
-            const newItems = getItems(newSelection);
-            const { added, removed, updated } = diffDbItems(oldItems, newItems);
-            if (_.isEmpty(added) && _.isEmpty(removed) && _.isEmpty(updated)) return;
+            const hasChanges = pdbMolstarActions.selection.hasChanges({
+                newSelection: newSelection,
+                prevSelection: currentSelection,
+            });
+            if (!hasChanges) return;
+
+            const onUrlRetrievalFailure = (args: RefinedModelGetArgs) => {
+                pluginFeedbackActions.error.whileRetrievingRefinedModelUrl(args);
+            };
+
+            const onFetchFailure = (args: RefinedModelGetArgs) => {
+                pluginFeedbackActions.error.whileFetchingRefinedModelUrl(args);
+            };
 
             const validSelection =
                 newSelection.type === "free"
-                    ? Promise.all(
-                          newSelection.refinedModels.map(async model => {
-                              const { pdbId, emdbId } = getRefinedModelIds(model);
-                              const args = {
-                                  pdbId: pdbId,
-                                  emdbId: emdbId,
-                                  method: model.type,
-                              };
-                              const filenameUrl = await getRefinedModelUrl(args).catch(err => {
-                                  pdbePlugin.canvas.showToast({
-                                      title: i18n.t("Error"),
-                                      message: loaderErrors.refinedModelUnexpectedError(args),
-                                      key: errorsKeys.refinedModelUnexpectedError,
-                                  });
-                                  return Promise.reject(err);
-                              });
-                              return await checkModelUrl({
-                                  id: pdbId,
-                                  url: filenameUrl,
-                              }).then(res => {
-                                  if (res.loaded) return model;
-                                  else {
-                                      pdbePlugin.canvas.showToast({
-                                          title: i18n.t("Error"),
-                                          message: getErrorByStatus(model.id, res.status),
-                                          key: errorKeyByStatus(res.status),
-                                      });
-                                      return undefined;
-                                  }
-                              });
-                          })
-                      ).then(models => _.compact(models))
+                    ? externalModel.filterOnlyValidRefinedModels({
+                          refinedModels: newSelection.refinedModels,
+                          onUrlRetrievalFailure: onUrlRetrievalFailure,
+                          onFetchFailure: onFetchFailure,
+                      })
                     : Promise.resolve([]);
 
             validSelection.then(newValidModels => {
@@ -194,23 +186,17 @@ export function usePdbePlugin(options: MolecularStructureProps) {
                     ...newSelection,
                     refinedModels: newValidModels,
                 };
-                const newRefinedItems = getItems(refinedNewSelection);
-                const {
-                    added: refinedAdded,
-                    removed: refinedRemoved,
-                    updated: refinedUpdated,
-                } = diffDbItems(oldItems, newRefinedItems);
+
                 /* Refined added/removed/updated are only valid models and when there is a change on them.
             Changes on not valid models will not trigger applySelectionChangesToPlugin() but on setSelection()
             to remove unvalid ones*/
 
-                const hasChanges = !(
-                    _.isEmpty(refinedAdded) &&
-                    _.isEmpty(refinedRemoved) &&
-                    _.isEmpty(refinedUpdated)
-                );
+                const hasChanges = pdbMolstarActions.selection.hasChanges({
+                    newSelection: refinedNewSelection,
+                    prevSelection: currentSelection,
+                });
 
-                if (hasChanges)
+                if (hasChanges && pdbePlugin)
                     updateLoader(
                         "updateVisualPlugin",
                         applySelectionChangesToPlugin(
@@ -218,13 +204,20 @@ export function usePdbePlugin(options: MolecularStructureProps) {
                             molstarState,
                             refinedNewSelection,
                             updateLoader,
-                            getRefinedModelUrl
+                            externalModel.getRefinedModelUrl
                         )
                     );
                 setSelection(refinedNewSelection);
             });
         },
-        [getRefinedModelUrl, pdbePlugin, setSelection, updateLoader]
+        [
+            externalModel,
+            pdbMolstarActions.selection,
+            pdbePlugin,
+            pluginFeedbackActions.error,
+            setSelection,
+            updateLoader,
+        ]
     );
 
     const updatePluginOnNewSelection = React.useCallback(() => {
@@ -246,15 +239,24 @@ export function usePdbePlugin(options: MolecularStructureProps) {
             compositionRoot.getRelatedModels.emdbFromPdb(pdbId).run(pdbEmdbId => {
                 if (emdbId !== pdbEmdbId || (pdbEmdbId === undefined && emdbId === undefined)) {
                     // Explicitly check for undefined for those models where there is no emdbId
-                    updateSelection(currentSelection, setMainItem(newSelection, pdbEmdbId, "emdb"));
+                    checkSelectionChangesWithRefinedModelUrlCheckingAndTriggerChanges(
+                        currentSelection,
+                        setMainItem(newSelection, pdbEmdbId, "emdb")
+                    );
                 }
             }, console.error);
         } else if (emdbId && getMainItem(currentSelection, "pdb") === undefined) {
             compositionRoot.getRelatedModels.pdbFromEmdb(emdbId).run(pdbId => {
-                updateSelection(currentSelection, setMainItem(newSelection, pdbId, "pdb"));
+                checkSelectionChangesWithRefinedModelUrlCheckingAndTriggerChanges(
+                    currentSelection,
+                    setMainItem(newSelection, pdbId, "pdb")
+                );
             }, console.error);
         } else {
-            updateSelection(currentSelection, newSelection);
+            checkSelectionChangesWithRefinedModelUrlCheckingAndTriggerChanges(
+                currentSelection,
+                newSelection
+            );
         }
     }, [
         pdbePlugin,
@@ -263,7 +265,7 @@ export function usePdbePlugin(options: MolecularStructureProps) {
         setPrevSelection,
         newSelection,
         compositionRoot.getRelatedModels,
-        updateSelection,
+        checkSelectionChangesWithRefinedModelUrlCheckingAndTriggerChanges,
     ]);
 
     const updatePluginOnNewSelectionEffect = updatePluginOnNewSelection;

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPluginHelpers.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPluginHelpers.ts
@@ -49,8 +49,14 @@ export const loaderErrors = {
     pdbRequest: (url: string, status: number) =>
         i18n.t(`Error loading PDB model: url=${url} - ${status}`),
     request: (url: string, status: number) => i18n.t(`Error loading model: url=${url} - ${status}`),
-    refinedModelUnexpectedError: (args: RefinedModelGetArgs) =>
-        i18n.t(`Unexpected error while loading refined model: ${refinedModelArgsToString(args)}`),
+    refinedModelUnableToFindModelUrl: (args: RefinedModelGetArgs) =>
+        i18n.t("Unable to find refined model URL: {{args}}", {
+            args: refinedModelArgsToString(args),
+        }),
+    refinedModelUnableToFetch: (args: RefinedModelGetArgs) =>
+        i18n.t("Unable to fetch refined model URL: {{args}}", {
+            args: refinedModelArgsToString(args),
+        }),
 };
 
 export const errorsKeys = _.mapValues(loaderErrors, (_v, k) => k);
@@ -60,13 +66,14 @@ export function setVisibility(plugin: PDBeMolstarPlugin, item: DbItem) {
     return plugin.visual.setVisibility(selector, item.visible || false);
 }
 
-export async function highlight(
-    plugin: PDBeMolstarPlugin,
-    chains: Maybe<PdbInfo["chains"]>,
-    selection: BaseSelection,
-    molstarState: MolstarStateRef,
-    focus = true
-): Promise<void> {
+export async function highlight(args: {
+    plugin: PDBeMolstarPlugin;
+    chains: Maybe<PdbInfo["chains"]>;
+    selection: BaseSelection;
+    molstarState: MolstarStateRef;
+    focus: Maybe<boolean>;
+}): Promise<void> {
+    const { plugin, chains, selection, molstarState, focus = true } = args;
     plugin.visual.clearSelection().catch(_err => {});
     plugin.visual.clearHighlight().catch(_err => {}); //remove previous highlight
     const ligandsView = getLigandView(selection);
@@ -110,7 +117,7 @@ export function getLigandView(selection: BaseSelection): LigandView | undefined 
     };
 }
 
-type MolstarStateRef = React.MutableRefObject<MolstarState>;
+export type MolstarStateRef = React.MutableRefObject<MolstarState>;
 
 export async function applySelectionChangesToPlugin(
     plugin: PDBeMolstarPlugin,
@@ -149,8 +156,8 @@ export async function applySelectionChangesToPlugin(
                 const filenameUrl = await getRefinedModelUrl(args).catch(err => {
                     plugin.canvas.showToast({
                         title: i18n.t("Error"),
-                        message: loaderErrors.refinedModelUnexpectedError(args),
-                        key: errorsKeys.refinedModelUnexpectedError,
+                        message: loaderErrors.refinedModelUnableToFindModelUrl(args),
+                        key: errorsKeys.refinedModelUnableToFindModelUrl,
                     });
                     return Promise.reject(err);
                 });

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPluginHelpers.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePdbPluginHelpers.ts
@@ -119,6 +119,74 @@ export function getLigandView(selection: BaseSelection): LigandView | undefined 
 
 export type MolstarStateRef = React.MutableRefObject<MolstarState>;
 
+const getTitle = (idx: number, items: DbItem[], modelType: Type) => {
+    return items.length > 1
+        ? i18n.t(`Loading ${modelType.toUpperCase()} (${idx + 1}/${items.length})...`)
+        : i18n.t(`Loading ${modelType.toUpperCase()}...`);
+};
+
+export const loadRefinedItems = (args: {
+    plugin: PDBeMolstarPlugin;
+    updateLoader: MolecularStructureProps["updateLoader"];
+    getRefinedModelUrl: (args: RefinedModelGetArgs) => Promise<string>;
+    molstarState: MolstarStateRef;
+}) => async (items: DbItem<RefinedModelType>[]) => {
+    const { plugin, updateLoader, getRefinedModelUrl, molstarState } = args;
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item) {
+            const { pdbId, emdbId } = getRefinedModelIds(item);
+            const args = {
+                pdbId: pdbId,
+                emdbId: emdbId,
+                method: item.type,
+            };
+
+            const filenameUrl = await getRefinedModelUrl(args).catch(err => {
+                plugin.canvas.showToast({
+                    title: i18n.t("Error"),
+                    message: loaderErrors.refinedModelUnableToFindModelUrl(args),
+                    key: errorsKeys.refinedModelUnableToFindModelUrl,
+                });
+                return Promise.reject(err);
+            });
+            await checkModelUrl({ id: item.id, url: filenameUrl }).then(async res => {
+                if (res.loaded) {
+                    const loadParams: LoadParams = {
+                        url: filenameUrl,
+                        label: item.id,
+                        format: filenameUrl.endsWith(".pdb") ? "pdb" : "mmcif",
+                        isBinary: false,
+                        assemblyId: "1",
+                    };
+                    await updateLoader(
+                        "loadModel",
+                        plugin.load(loadParams, false),
+                        getTitle(i, items, item.type)
+                    );
+                    setVisibility(plugin, item);
+                    updateItems(molstarState, item);
+                } else
+                    plugin.canvas.showToast({
+                        title: i18n.t("Error"),
+                        message: getErrorByStatus(item.id, res.status),
+                        key: errorKeyByStatus(res.status),
+                    });
+            });
+        }
+    }
+};
+
+export const oldItems = (molstarState: MolstarStateRef) =>
+    molstarState.current.type === "pdb" ? molstarState.current.items : [];
+
+export const updateItems = (molstarState: MolstarStateRef, item: DbItem) => {
+    molstarState.current = MolstarStateActions.updateItems(
+        molstarState.current,
+        _.unionBy(oldItems(molstarState), [item], getId)
+    );
+};
+
 export async function applySelectionChangesToPlugin(
     plugin: PDBeMolstarPlugin,
     molstarState: MolstarStateRef,
@@ -128,69 +196,9 @@ export async function applySelectionChangesToPlugin(
 ): Promise<void> {
     if (molstarState.current.type !== "pdb") return;
 
-    const oldItems = () => (molstarState.current.type === "pdb" ? molstarState.current.items : []);
-    const updateItems = (item: DbItem) => {
-        molstarState.current = MolstarStateActions.updateItems(
-            molstarState.current,
-            _.unionBy(oldItems(), [item], getId)
-        );
-    };
-
-    const getTitle = (idx: number, items: DbItem[], modelType: Type) => {
-        return items.length > 1
-            ? i18n.t(`Loading ${modelType.toUpperCase()} (${idx + 1}/${items.length})...`)
-            : i18n.t(`Loading ${modelType.toUpperCase()}...`);
-    };
-
-    const loadRefinedItems = async (items: DbItem<RefinedModelType>[]) => {
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            if (item) {
-                const { pdbId, emdbId } = getRefinedModelIds(item);
-                const args = {
-                    pdbId: pdbId,
-                    emdbId: emdbId,
-                    method: item.type,
-                };
-
-                const filenameUrl = await getRefinedModelUrl(args).catch(err => {
-                    plugin.canvas.showToast({
-                        title: i18n.t("Error"),
-                        message: loaderErrors.refinedModelUnableToFindModelUrl(args),
-                        key: errorsKeys.refinedModelUnableToFindModelUrl,
-                    });
-                    return Promise.reject(err);
-                });
-                await checkModelUrl({ id: item.id, url: filenameUrl }).then(async res => {
-                    if (res.loaded) {
-                        const loadParams: LoadParams = {
-                            url: filenameUrl,
-                            label: item.id,
-                            format: filenameUrl.endsWith(".pdb") ? "pdb" : "mmcif",
-                            isBinary: false,
-                            assemblyId: "1",
-                        };
-                        await updateLoader(
-                            "loadModel",
-                            plugin.load(loadParams, false),
-                            getTitle(i, items, item.type)
-                        );
-                        setVisibility(plugin, item);
-                        updateItems(item);
-                    } else
-                        plugin.canvas.showToast({
-                            title: i18n.t("Error"),
-                            message: getErrorByStatus(item.id, res.status),
-                            key: errorKeyByStatus(res.status),
-                        });
-                });
-            }
-        }
-    };
-
     const newItems = getItems(newSelection);
 
-    const { added, removed, updated } = diffDbItems(newItems, oldItems());
+    const { added, removed, updated } = diffDbItems(newItems, oldItems(molstarState));
 
     const pdbs = added.filter(item => item.type === "pdb");
     const emdbs = added.filter(item => item.type === "emdb");
@@ -209,7 +217,7 @@ export async function applySelectionChangesToPlugin(
 
     console.debug(
         "Update molstar:",
-        _({ oldItems: oldItems(), added, removed, updated })
+        _({ oldItems: oldItems(molstarState), added, removed, updated })
             .mapValues(objs => objs.map(obj => obj.id).join(", "))
             .pickBy()
             .value()
@@ -223,7 +231,7 @@ export async function applySelectionChangesToPlugin(
         plugin.visual.remove(getItemSelector(item));
         molstarState.current = MolstarStateActions.updateItems(
             molstarState.current,
-            _.differenceBy(oldItems(), [item], getId)
+            _.differenceBy(oldItems(molstarState), [item], getId)
         );
     }
 
@@ -231,7 +239,7 @@ export async function applySelectionChangesToPlugin(
         setVisibility(plugin, item);
         molstarState.current = MolstarStateActions.updateItems(
             molstarState.current,
-            oldItems().map(item_ => (item_.id === item.id ? item : item_))
+            oldItems(molstarState).map(item_ => (item_.id === item.id ? item : item_))
         );
     }
 
@@ -257,7 +265,7 @@ export async function applySelectionChangesToPlugin(
                             : i18n.t("Loading PDB...")
                     );
                     setVisibility(plugin, item);
-                    updateItems(item);
+                    updateItems(molstarState, item);
                 } else if (getMainItem(newSelection, "pdb") === pdbId)
                     updateLoader("loadModel", Promise.reject(getErrorByStatus(pdbId, res.status)));
                 if (!res.loaded)
@@ -289,7 +297,7 @@ export async function applySelectionChangesToPlugin(
                     );
                     setEmdbOpacity({ plugin, id: item.id, value: 0.5 });
                     setVisibility(plugin, item);
-                    updateItems(item);
+                    updateItems(molstarState, item);
                 } else
                     plugin.canvas.showToast({
                         title: i18n.t("Error"),
@@ -300,8 +308,16 @@ export async function applySelectionChangesToPlugin(
         }
     }
 
-    ([pdbRedo, isolde, refmac, phenix] as DbItem<RefinedModelType>[][]).forEach(items =>
-        loadRefinedItems(items)
+    await Promise.all(
+        ([pdbRedo, isolde, refmac, phenix] as DbItem<RefinedModelType>[][]).map(
+            async items =>
+                await loadRefinedItems({
+                    plugin,
+                    updateLoader,
+                    getRefinedModelUrl,
+                    molstarState,
+                })(items)
+        )
     );
 
     // Remove unused elements
@@ -313,7 +329,7 @@ export async function applySelectionChangesToPlugin(
         plugin.visual.remove(getItemSelector(item));
         molstarState.current = MolstarStateActions.updateItems(
             molstarState.current,
-            _.differenceBy(oldItems(), [item], getId)
+            _.differenceBy(oldItems(molstarState), [item], getId)
         );
     }
 

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePluginRef.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePluginRef.ts
@@ -103,14 +103,13 @@ export function usePluginRef(options: Options) {
         pdbeMolstarSequenceEventCompletedWrapper(setMolstarDefaultChain)
     );
 
+    const externalModel = React.useMemo(() => new ExternalModel(compositionRoot), [
+        compositionRoot,
+    ]);
+
     const getRefinedModelUrl = React.useCallback(
-        (args: RefinedModelGetArgs): Promise<string> => {
-            return compositionRoot.getRefinedModel
-                .execute(args)
-                .map(refinedModel => refinedModel.filenameUrl)
-                .toPromise();
-        },
-        [compositionRoot]
+        (args: RefinedModelGetArgs) => externalModel.getRefinedModelUrl(args),
+        [externalModel]
     );
 
     React.useEffect(() => {

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePluginRef.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/components/molecular-structure/usePluginRef.ts
@@ -16,6 +16,7 @@ import {
     getErrorByStatus,
     getLigandView,
     loaderErrors,
+    loadRefinedItems,
     setVisibility,
     urls,
 } from "./usePdbPluginHelpers";
@@ -28,6 +29,8 @@ import { MolstarState, MolstarStateActions } from "./MolstarState";
 import { getCurrentItems, loadEmdb, setEmdbOpacity } from "./molstar";
 import { RefinedModelGetArgs } from "../../../domain/repositories/RefinedModelRepository";
 import i18n from "../../utils/i18n";
+import { PluginFeedback } from "./PluginFeedback";
+import { ExternalModel } from "./ExternalModel";
 
 type Options = {
     prevSelectionRef: React.MutableRefObject<Selection | undefined>;
@@ -332,6 +335,7 @@ export function usePluginRef(options: Options) {
                     .catch(err => loadVoidMolstar(err));
             }
 
+            // FIXME: Mid-refactor. Not extracting as all SequenceView logic should be extracted along it in that case.
             async function initializePdbeMolstar(element: HTMLDivElement) {
                 subscribeSequenceComplete();
                 subscribeLoadComplete();
@@ -340,6 +344,48 @@ export function usePluginRef(options: Options) {
                 else if (pdbId) await loadFromPdb(pdbId, element);
                 else if (newSelection.type === "uploadData") await loadFromUploadData(element);
                 else loadVoidMolstar(loaderErrors.undefinedPdb);
+                loadRefinedModels();
+                // TODO: Also for overlay items should be...
+            }
+
+            //FIXME: To be deleted completely
+            // Async
+            function loadRefinedModels() {
+                if (newSelection.type !== "free") return;
+                const pluginFeedbackActions = new PluginFeedback(plugin, i18n).getActions();
+                const externalModel = new ExternalModel(compositionRoot);
+
+                const onUrlRetrievalFailure = (args: RefinedModelGetArgs) => {
+                    pluginFeedbackActions.error.whileRetrievingRefinedModelUrl(args);
+                };
+
+                const onFetchFailure = (args: RefinedModelGetArgs) => {
+                    pluginFeedbackActions.error.whileFetchingRefinedModelUrl(args);
+                };
+
+                externalModel
+                    .filterOnlyValidRefinedModels({
+                        refinedModels: newSelection.refinedModels,
+                        onUrlRetrievalFailure: onUrlRetrievalFailure,
+                        onFetchFailure: onFetchFailure,
+                    })
+                    .then(validModels => {
+                        if (validModels.length === newSelection.refinedModels.length) {
+                            console.debug("All refined models are valid");
+                            loadRefinedItems({
+                                plugin,
+                                updateLoader,
+                                getRefinedModelUrl,
+                                molstarState,
+                            })(validModels);
+                        } else {
+                            // Loading refinedModels through useEffect detecting changes in selection
+                            setSelection({
+                                ...newSelection,
+                                refinedModels: validModels,
+                            });
+                        }
+                    });
             }
 
             function loadEmdbIfNotPresent(): Promise<void> {

--- a/app/assets/javascripts/3dbio_viewer/src/webapp/view-models/Selection.ts
+++ b/app/assets/javascripts/3dbio_viewer/src/webapp/view-models/Selection.ts
@@ -213,6 +213,7 @@ export function setMainItem(
     };
 }
 
+// Used only when user manually removes. Not any other.
 export function removeOverlayItem(selection: Selection, id: string): Selection {
     if (selection.type !== "free") return selection;
     const overlay = selection.overlay.flatMap(item => (item.id === id ? [] : [item]));


### PR DESCRIPTION
### :pushpin: References

-   #244 

### :memo: Implementation

Previously `MolecularStructure.tsx` was helding all the logic for PdbeMolstar plugin. We previously made an effort to extract the state into two useHooks -> `usePdbPlugin()` and `usePluginRef()`. But that effort wasn't enough as there is a lot of complexity still being held. Due to that complexity, when refined models feature was added, two bugs appeared:
- Refined models not added on init (also applying to overlay items, referring to other pdbs and emdbs at the same time)
- And not updating the `MolstarStateRef` causing to repeatedly load several instances of the model (duplications)
- Nullable filenames external urls

This PR is a mid-refactor. It's a mid effort of extracting and moving some complexity out and improving readability while solving these mentioned bugs. And this PR isn't even the correct boilerplate of the refactor itself.